### PR TITLE
Modified Stage class to support MM's demo hardware

### DIFF
--- a/src/main/java/spim/setup/Stage.java
+++ b/src/main/java/spim/setup/Stage.java
@@ -1,6 +1,7 @@
 package spim.setup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -90,8 +91,11 @@ public class Stage extends Device {
 	 * @return A collection of the allowed velocities.
 	 */
 	public Collection<Double> getAllowedVelocities() {
-		if(!hasProperty("Velocity"))
-			return null;
+		if(!hasProperty("Velocity")) {
+			// if the stage hasn't got the Velocity property, we are probably on the demo stage,
+			// so let's return a fake value
+			return Arrays.asList(1.0);
+		}
 		
 		Collection<String> vals = getPropertyAllowedValues("Velocity");
 		List<Double> list = new ArrayList<Double>(vals.size());


### PR DESCRIPTION
In the original Stage class, a check for the Velocity parameter of the stage is used - a property that the MicroManager-provided hardware does not support.

This PR lets getAllowedVelocities return fake values for these velocities, enabling the SPIMAcq plugin to be used with the MM demo hardware (for a working config see https://raw.githubusercontent.com/skalarproduktraum/mmconfigs/master/demo_only.cfg)
