### PR TITLE
Support for Coherent OBIS lasers

### DIFF
--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -792,6 +792,12 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 		int deflp = (int) ((setup.getLaser() != null ? setup.getLaser().getPower() : 1) * 1000);
 		int maxlp = (int) ((setup.getLaser() != null ? setup.getLaser().getMaxPower() : 1) * 1000);
 
+		if(deflp == 0) {
+			deflp = 1;
+		}
+
+		ReportingUtils.logDebugMessage("Laser min/max/def:" + minlp + " " + maxlp + " " + deflp);
+
 		laserSlider = new SteppedSlider("Laser Power:", minlp, maxlp, 1, deflp, SteppedSlider.LABEL_LEFT | SteppedSlider.INCREMENT_BUTTONS) {
 			@Override
 			public void valueChanged() {

--- a/src/main/java/spim/setup/CoherentObis.java
+++ b/src/main/java/spim/setup/CoherentObis.java
@@ -1,0 +1,37 @@
+package spim.setup;
+
+import mmcorej.CMMCore;
+import org.micromanager.utils.ReportingUtils;
+import spim.setup.SPIMSetup.SPIMDevice;
+
+public class CoherentObis extends Laser {
+    static {
+        Device.installFactory(new Factory() {
+            @Override
+            public Device manufacture(CMMCore core, String label) {
+                return new CoherentObis(core, label);
+            }
+        }, "CoherentObis", SPIMDevice.LASER1, SPIMDevice.LASER2);
+    }
+
+    public CoherentObis(CMMCore core, String label) {
+        super(core, label);
+    }
+
+    @Override
+    public void setPower(double power) { setProperty("PowerSetpoint", power * 1000); }
+
+    @Override
+    public double getPower() { return getPropertyDouble("PowerSetpoint") / 1000.0; }
+
+    @Override
+    public double getMinPower() {
+        return getPropertyDouble("Minimum Laser Power");
+    }
+
+    @Override
+    public double getMaxPower() {
+        return getPropertyDouble("Maximum Laser Power");
+    }
+
+}


### PR DESCRIPTION
This PR adds support for Coherent's OBIS lasers, which unfortunately tend to report power units differently than Cubes from the same brand.

It also adds a debugging output for min, max and default laser power, so issues with that can be more easily identified in the future.