### PR TITLE
Handle the delay issue and anti-drift error fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>sc.fiji</groupId>
+            <artifactId>spim_data</artifactId>
+            <version>1.0.0-beta-7</version>
+        </dependency>
+        <dependency>
+            <groupId>sc.fiji</groupId>
+            <artifactId>bigdataviewer-core</artifactId>
+            <version>1.2.2</version>
+        </dependency>
     </dependencies>
 
 	<!-- NB: for project parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,26 @@
 
 	<properties>
 		<enforcer.skip>true</enforcer.skip>
+        <bio-formats.version>5.1.2</bio-formats.version>
 	</properties>
 
 	<dependencies>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-gpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>ome-xml</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>10.0.1</version>
+		<version>16.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -149,12 +149,12 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>spim_data</artifactId>
-            <version>1.0.0-beta-7</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>bigdataviewer-core</artifactId>
-            <version>1.2.2</version>
+            <version>2.1.0</version>
         </dependency>
     </dependencies>
 
@@ -164,5 +164,9 @@
 			<id>imagej.releases</id>
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
+        <repository>
+            <id>fiji.releases</id>
+            <url>http://dev.loci.wisc.edu/maven2/releases</url>
+        </repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <groupId>ome</groupId>
             <artifactId>ome-xml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-bsd</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>
@@ -142,7 +146,7 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+    </dependencies>
 
 	<!-- NB: for project parent -->
 	<repositories>

--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -167,6 +167,7 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 	private JCheckBox antiDriftXInversed;
 	private JCheckBox antiDriftYInversed;
 	private JCheckBox antiDriftZInversed;
+	private JCheckBox antiDriftAutoApplied;
 
 	private JCheckBox laseStackCheckbox;
 
@@ -893,12 +894,15 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 		antiDriftPanel.setBorder( BorderFactory.createTitledBorder("Anti-Drift") );
 		antiDriftPanel.add( antiDriftCheckbox );
 
+		antiDriftAutoApplied = new JCheckBox( "Automatic apply the suggested value" );
+		antiDriftAutoApplied.setEnabled( false );
 		antiDriftXInversed = new JCheckBox( "Inverse X offset value" );
 		antiDriftXInversed.setEnabled( false );
 		antiDriftYInversed = new JCheckBox( "Inverse Y offset value" );
 		antiDriftYInversed.setEnabled( false );
 		antiDriftZInversed = new JCheckBox( "Inverse Z offset value" );
 		antiDriftZInversed.setEnabled( false );
+		antiDriftPanel.add( antiDriftAutoApplied );
 		antiDriftPanel.add( antiDriftXInversed );
 		antiDriftPanel.add( antiDriftYInversed );
 		antiDriftPanel.add( antiDriftZInversed );
@@ -909,12 +913,14 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 			{
 				if(itemEvent.getStateChange() == ItemEvent.SELECTED)
 				{
+					antiDriftAutoApplied.setEnabled( true );
 					antiDriftXInversed.setEnabled( true );
 					antiDriftYInversed.setEnabled( true );
 					antiDriftZInversed.setEnabled( true );
 				}
 				else
 				{
+					antiDriftAutoApplied.setEnabled( false );
 					antiDriftXInversed.setEnabled( false );
 					antiDriftYInversed.setEnabled( false );
 					antiDriftZInversed.setEnabled( false );
@@ -1817,8 +1823,12 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 					params.setAntiDrift(new AntiDriftController.Factory() {
 						@Override
 						public AntiDriftController newInstance(Params p, Row r) {
-							return AntiDriftController.newInstance(output, p, r,
-									antiDriftXInversed.isSelected(), antiDriftYInversed.isSelected(), antiDriftZInversed.isSelected());
+							return AntiDriftController.newInstance(
+									output, p, r,
+									antiDriftAutoApplied.isSelected(),
+									antiDriftXInversed.isSelected(),
+									antiDriftYInversed.isSelected(),
+									antiDriftZInversed.isSelected());
 						}
 					});
 

--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -1864,6 +1864,10 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 						tileCount = -2; //in this case counting is harder, because one would have to compare all the rows
 					};
 
+					// titleCount should not be -2, which makes only two angles for all the acquisition
+					tileCount = (tileCount < 0) ? 1 : tileCount;
+					ij.IJ.log("Tiles count: "+ tileCount);
+
 					OutputHandler handler = new OMETIFFHandler(
 						mmc, output, acqFilenamePrefix.getText(), null, null, null, "t", //what is the purpose of defining parameters and then passing null anyway?
 						acqRows, timeSeqs, timeStep, tileCount

--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -903,6 +903,39 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 
 
 		//////////////////////////////////////////////////////////////////////////////////
+		// Information box
+		JPanel pixelCalibrationPanel = new JPanel();
+		pixelCalibrationPanel.setLayout( new BoxLayout( pixelCalibrationPanel, BoxLayout.PAGE_AXIS ) );
+		pixelCalibrationPanel.setBorder( BorderFactory.createTitledBorder( "Info" ) );
+
+		JPanel labelTextBox = new JPanel();
+		labelTextBox.setLayout( new FlowLayout( FlowLayout.LEADING ) );
+		labelTextBox.add( new JLabel( "Current Pixel size:" ) );
+		currentPixelSize = new JLabel( NumberUtils.doubleToDisplayString( mmc.getPixelSizeUm() ) );
+		labelTextBox.add( currentPixelSize );
+		labelTextBox.add( new JLabel( "um/pixel" ) );
+		labelTextBox.setAlignmentX( Component.LEFT_ALIGNMENT );
+		pixelCalibrationPanel.add( labelTextBox );
+
+		JButton updatePixelSizeBtn = new JButton( "Cal. Pix. Size" );
+		updatePixelSizeBtn.addActionListener( new ActionListener()
+		{
+			@Override public void actionPerformed( ActionEvent actionEvent )
+			{
+				PixelSizeWindow psw = new PixelSizeWindow(mmc, gui, new ActionListener()
+				{
+					@Override public void actionPerformed( ActionEvent actionEvent )
+					{
+						currentPixelSize.setText( NumberUtils.doubleToDisplayString( mmc.getPixelSizeUm() ) );
+					}
+				});
+				psw.setVisible( true );
+			}
+		} );
+		pixelCalibrationPanel.add( updatePixelSizeBtn );
+
+
+		//////////////////////////////////////////////////////////////////////////////////
 		// Anti-Drift panel
 		antiDriftCheckbox = new JCheckBox("Use Anti-Drift");
 		antiDriftCheckbox.setSelected(false);
@@ -1000,7 +1033,7 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 		addLine(right, Justification.RIGHT, "Laser power (mW):", laserPower, "Exposure (ms):", exposure);
 		addLine(right, Justification.STRETCH, laserSlider);
 		addLine(right, Justification.STRETCH, exposureSlider);
-		addLine(right, Justification.RIGHT, antiDriftPanel, optionPanel);
+		addLine(right, Justification.RIGHT, pixelCalibrationPanel, antiDriftPanel, optionPanel);
 		addLine(right, Justification.RIGHT, "Output directory:", acqSaveDir, pickDirBtn);
 
 		JPanel bottom = new JPanel();

--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -1245,6 +1245,9 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 		step = stage != null ? stage.getStepSize() : step;
 		double def = stage != null ? stage.getPosition() : 0;
 
+		// Sometimes, stage.getPosition returns minus values
+		def = Math.max( min, def );
+
 		return new SteppedSlider(dev.getText(), min, max, step, def, options) {
 			@Override
 			public void valueChanged() {

--- a/src/main/java/spim/SPIMAcquisition.java
+++ b/src/main/java/spim/SPIMAcquisition.java
@@ -415,7 +415,7 @@ public class SPIMAcquisition implements MMPlugin, ItemListener, ActionListener {
 		left.add(Box.createVerticalStrut(8));
 		addLine(left, Justification.STRETCH, rotationSlider);
 
-		autoReplaceMMControls = new JCheckBox("SPIM Mouse Controls");
+		autoReplaceMMControls = new JCheckBox("Invert Y Mouse Control");
 		autoReplaceMMControls.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ae) {

--- a/src/main/java/spim/acquisition/Params.java
+++ b/src/main/java/spim/acquisition/Params.java
@@ -34,6 +34,7 @@ public class Params
 	private int					zWaitMillis;
 
 	private boolean				profile;
+	private boolean				abortWhenDelayed = false;
 
 	public Params() {
 		this(null, null, null, 0D, 0, false, null, null, false, null);
@@ -240,4 +241,13 @@ public class Params
 		this.profile = profile;
 	}
 
+	public boolean isAbortWhenDelayed()
+	{
+		return abortWhenDelayed;
+	}
+
+	public void setAbortWhenDelayed( boolean abortWhenDelayed )
+	{
+		this.abortWhenDelayed = abortWhenDelayed;
+	}
 }

--- a/src/main/java/spim/acquisition/Program.java
+++ b/src/main/java/spim/acquisition/Program.java
@@ -462,6 +462,7 @@ public class Program
 							Thread.sleep(params.getSettleDelay());
 							ReportingUtils.logMessage( "After 2 in-loop: Thread.sleep(params.getSettleDelay());" );
 						} catch(InterruptedException ie) {
+							checker.stop();
 							return cleanAbort(params, liveOn, autoShutter, continuousThread);
 						}
 						ReportingUtils.logMessage( "After 2 in-loop: done." );

--- a/src/main/java/spim/acquisition/Program.java
+++ b/src/main/java/spim/acquisition/Program.java
@@ -371,9 +371,9 @@ public class Program
 						ad = params.getAntiDrift(row);
 						ad.setCallback(new AntiDrift.Callback() {
 							public void applyOffset(Vector3D offs) {
-								offs = new Vector3D(offs.getX()*-core.getPixelSizeUm(), offs.getY()*-core.getPixelSizeUm(), -offs.getZ());
-								ij.IJ.log(String.format("TP %d view %d: Offset: %s", tp, rown, offs.toString()));
-								row.translate(offs);
+								Vector3D appliedOffsset = new Vector3D(offs.getX()*-core.getPixelSizeUm(), offs.getY()*-core.getPixelSizeUm(), -offs.getZ());
+								ij.IJ.log(String.format("TP %d view %d: Offset: %s", tp, rown, appliedOffsset.toString()));
+								row.translate(appliedOffsset);
 							}
 						});
 					}

--- a/src/main/java/spim/acquisition/Program.java
+++ b/src/main/java/spim/acquisition/Program.java
@@ -371,7 +371,11 @@ public class Program
 						ad = params.getAntiDrift(row);
 						ad.setCallback(new AntiDrift.Callback() {
 							public void applyOffset(Vector3D offs) {
-								Vector3D appliedOffsset = new Vector3D(offs.getX()*-core.getPixelSizeUm(), offs.getY()*-core.getPixelSizeUm(), -offs.getZ());
+								Vector3D appliedOffsset = new Vector3D(
+										offs.getX()*-core.getPixelSizeUm(),
+										offs.getY()*-core.getPixelSizeUm(),
+										-offs.getZ());
+
 								ij.IJ.log(String.format("TP %d view %d: Offset: %s", tp, rown, appliedOffsset.toString()));
 								row.translate(appliedOffsset);
 							}

--- a/src/main/java/spim/acquisition/Program.java
+++ b/src/main/java/spim/acquisition/Program.java
@@ -405,17 +405,10 @@ public class Program
 					prof.get("Output").stop();
 
 				if(row.getZStartPosition() == row.getZEndPosition()) {
-					DelayChecker checker = new DelayChecker( 5000 );
-
-					//TODO: added logging info before image synchronization
-					ReportingUtils.logMessage( "Before 1: core.waitForImageSynchro();" );
+					DelayChecker checker = new DelayChecker( params.isAbortWhenDelayed()? Thread.currentThread(): null, 5000 );
 
 					core.waitForImageSynchro();
-
-					ReportingUtils.logMessage( "Before 1: Delay " + params.getSettleDelay() );
 					Thread.sleep(params.getSettleDelay());
-
-					ReportingUtils.logMessage( "After 1: done." );
 
 					if(!params.isContinuous()) {
 						TaggedImage ti = snapImage(setup, !params.isIllumFullStack());
@@ -432,17 +425,11 @@ public class Program
 
 				} else if (!row.getZContinuous()) {
 
-					ReportingUtils.logMessage( "Before 2 loop: setup.getZStage().getPosition();" );
-
 					double start = setup.getZStage().getPosition();
-
-					ReportingUtils.logMessage( "Before 2 loop: start + row.getZEndPosition() - row.getZStartPosition();" );
 
 					double end = start + row.getZEndPosition() - row.getZStartPosition();
 
-					ReportingUtils.logMessage( "Before 2 loop: started." );
-
-					DelayChecker checker = new DelayChecker( 5000 );
+					DelayChecker checker = new DelayChecker( params.isAbortWhenDelayed()? Thread.currentThread(): null, 5000 );
 
 					for(double zStart = start; zStart <= end; zStart += row.getZStepSize()) {
 						// Reset delay checker
@@ -451,25 +438,17 @@ public class Program
 
 						if(params.doProfiling())
 						{
-							ReportingUtils.logMessage( "Before 2 in-loop: doProfiling" );
 							prof.get( "Movement" ).start();
 						}
-
-						ReportingUtils.logMessage( "Before 2 in-loop: setup.getZStage().setPosition(zStart);" );
 						setup.getZStage().setPosition(zStart);
-
-						ReportingUtils.logMessage( "Before 2 in-loop: core.waitForImageSynchro();" );
 						core.waitForImageSynchro();
 
 						try {
-							ReportingUtils.logMessage( "Before 2 in-loop: Delay " + params.getSettleDelay() );
 							Thread.sleep(params.getSettleDelay());
-							ReportingUtils.logMessage( "After 2 in-loop: Thread.sleep(params.getSettleDelay());" );
 						} catch(InterruptedException ie) {
 							checker.stop();
 							return cleanAbort(params, liveOn, autoShutter, continuousThread);
 						}
-						ReportingUtils.logMessage( "After 2 in-loop: done." );
 
 						if(params.doProfiling())
 							prof.get("Movement").stop();

--- a/src/main/java/spim/acquisition/Program.java
+++ b/src/main/java/spim/acquisition/Program.java
@@ -234,7 +234,9 @@ public class Program
 			// TEMPORARY: Don't re-enable live mode. This keeps our laser off.
 //			MMStudio.getInstance().enableLiveMode(live);
 
-			p.getOutputHandler().finalizeAcquisition();
+			// Abortion with false flag
+			p.getOutputHandler().finalizeAcquisition(false);
+
 			return p.getOutputHandler().getImagePlus();
 		} catch(Exception e) {
 			return null;
@@ -562,7 +564,8 @@ public class Program
 		if(params.doProfiling())
 			prof.get("Output").start();
 
-		handler.finalizeAcquisition();
+		// Finalized acquisition with true flag
+		handler.finalizeAcquisition(true);
 
 		if(params.doProfiling())
 			prof.get("Output").stop();

--- a/src/main/java/spim/algorithm/AbstractAntiDrift.java
+++ b/src/main/java/spim/algorithm/AbstractAntiDrift.java
@@ -63,9 +63,9 @@ public abstract class AbstractAntiDrift implements AntiDrift
 
 	public abstract void addXYSlice(ImageProcessor ip);
 
-	public abstract void finishStack();
+	public abstract Vector3D finishStack();
 
-	public abstract void updateOffset(Vector3D offset);
+	public abstract Vector3D updateOffset(Vector3D offset);
 
 	public void setCallback(Callback cb) {
 		callback = cb;

--- a/src/main/java/spim/algorithm/AntiDrift.java
+++ b/src/main/java/spim/algorithm/AntiDrift.java
@@ -23,14 +23,14 @@ public interface AntiDrift
 	/**
 	 * Finish stack.
 	 */
-	void finishStack();
+	Vector3D finishStack();
 
 	/**
 	 * Update offset.
 	 *
 	 * @param offset the offset
 	 */
-	void updateOffset(Vector3D offset);
+	Vector3D updateOffset(Vector3D offset);
 
 	/**
 	 * The interface Callback.

--- a/src/main/java/spim/algorithm/DefaultAntiDrift.java
+++ b/src/main/java/spim/algorithm/DefaultAntiDrift.java
@@ -36,7 +36,7 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 
 		Vector3D suggested = latest.correlateAndAverage(first);
 
-		log.info( suggested.toString() );
+		log.info( "Suggested: " + suggested.toString() );
 
 		setLastCorrection( suggested );
 	}
@@ -44,6 +44,11 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 	@Override public void updateOffset( Vector3D offset )
 	{
 		offset = offset.add(lastCorrection);
+
+		log.info( "Last correction: " + offset );
+
 		setLastCorrection( offset );
+
+		log.info( "Last correction: " + offset );
 	}
 }

--- a/src/main/java/spim/algorithm/DefaultAntiDrift.java
+++ b/src/main/java/spim/algorithm/DefaultAntiDrift.java
@@ -29,7 +29,7 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 		latest.addXYSlice( ip );
 	}
 
-	@Override public void finishStack()
+	@Override public Vector3D finishStack()
 	{
 		if(first == null)
 			first = latest;
@@ -38,17 +38,15 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 
 		log.info( "Suggested: " + suggested.toString() );
 
-		setLastCorrection( suggested );
+		return suggested;
 	}
 
-	@Override public void updateOffset( Vector3D offset )
+	@Override public Vector3D updateOffset( Vector3D offset )
 	{
 		offset = offset.add(lastCorrection);
 
 		log.info( "Last correction: " + offset );
 
-		setLastCorrection( offset );
-
-		log.info( "Last correction: " + offset );
+		return offset;
 	}
 }

--- a/src/main/java/spim/algorithm/DefaultAntiDrift.java
+++ b/src/main/java/spim/algorithm/DefaultAntiDrift.java
@@ -10,7 +10,7 @@ import java.util.logging.Logger;
  */
 public class DefaultAntiDrift extends AbstractAntiDrift
 {
-	Logger log = Logger.getLogger(DefaultAntiDrift.class.getName());
+//	Logger log = Logger.getLogger(DefaultAntiDrift.class.getName());
 	/**
 	 * Instantiates a new DefaultAntiDrift class using PhaseCorrelation.
 	 */
@@ -36,17 +36,17 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 
 		Vector3D suggested = latest.correlateAndAverage(first);
 
-		log.info( "Suggested: " + suggested.toString() );
+		ij.IJ.log( "Suggested offset: " + suggested.toString() );
 
 		return suggested;
 	}
 
 	@Override public Vector3D updateOffset( Vector3D offset )
 	{
-		offset = offset.add(lastCorrection);
+		Vector3D lastOffset = offset.add(lastCorrection);
 
-		log.info( "Last correction: " + offset );
+		ij.IJ.log( "Last offset: " + lastOffset );
 
-		return offset;
+		return lastOffset;
 	}
 }

--- a/src/main/java/spim/algorithm/DefaultAntiDrift.java
+++ b/src/main/java/spim/algorithm/DefaultAntiDrift.java
@@ -22,6 +22,9 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 	@Override public void startNewStack()
 	{
 		latest = new Projections();
+
+		if(first == null)
+			first = latest;
 	}
 
 	@Override public void addXYSlice( ImageProcessor ip )
@@ -31,9 +34,6 @@ public class DefaultAntiDrift extends AbstractAntiDrift
 
 	@Override public Vector3D finishStack()
 	{
-		if(first == null)
-			first = latest;
-
 		Vector3D suggested = latest.correlateAndAverage(first);
 
 		ij.IJ.log( "Suggested offset: " + suggested.toString() );

--- a/src/main/java/spim/controller/AntiDriftController.java
+++ b/src/main/java/spim/controller/AntiDriftController.java
@@ -124,7 +124,6 @@ public class AntiDriftController implements AntiDrift.Callback
 	{
 		if(gui.isVisible())
 		{
-			applyOffset( gui.getOffset() );
 			gui.setVisible( false );
 			gui.dispose();
 		}

--- a/src/main/java/spim/controller/AntiDriftController.java
+++ b/src/main/java/spim/controller/AntiDriftController.java
@@ -114,7 +114,7 @@ public class AntiDriftController implements AntiDrift.Callback
 	{
 		if(gui.isVisible())
 		{
-			antiDrift.updateOffset( gui.getOffset() );
+			applyOffset( gui.getOffset() );
 			gui.setVisible( false );
 			gui.dispose();
 		}
@@ -157,11 +157,11 @@ public class AntiDriftController implements AntiDrift.Callback
 			antiDrift.writeDiff( getOutFile("initial"), antiDrift.getLastCorrection(), zratio, center );
 
 		// Process anti-drift
-		antiDrift.finishStack();
+		Vector3D init = antiDrift.finishStack();
 
 		// After the anti-drift processing
 		if(null != outputDir)
-			antiDrift.writeDiff( getOutFile("suggested"), antiDrift.getLastCorrection(), zratio, center );
+			antiDrift.writeDiff( getOutFile("suggested"), init, zratio, center );
 
 		// Invoke GUI for fine-tuning
 		gui.setVisible( true );
@@ -169,7 +169,7 @@ public class AntiDriftController implements AntiDrift.Callback
 		gui.setCallback( this );
 		gui.setZratio( zratio );
 		gui.updateScale( antiDrift.getLatest().largestDimension() * 2 );
-		gui.setOffset( antiDrift.getLastCorrection() );
+		gui.setOffset( init );
 		gui.setCenter( center );
 		gui.setBefore( antiDrift.getFirst() );
 		gui.setAfter( antiDrift.getLatest() );
@@ -189,7 +189,9 @@ public class AntiDriftController implements AntiDrift.Callback
 
 	public void applyOffset( Vector3D offset )
 	{
-		antiDrift.updateOffset( offset );
+		offset = antiDrift.updateOffset( offset );
+
+		antiDrift.setLastCorrection( offset );
 
 		// Callback function for ProgrammaticAcquisitor class
 		// refer spim/progacq/ProgrammaticAcquisitor.java:366

--- a/src/main/java/spim/controller/AntiDriftController.java
+++ b/src/main/java/spim/controller/AntiDriftController.java
@@ -8,6 +8,7 @@ import spim.algorithm.AntiDrift;
 import spim.gui.calibration.AntiDriftAdjustWindow;
 import spim.algorithm.DefaultAntiDrift;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.util.logging.Logger;
 
@@ -44,7 +45,7 @@ public class AntiDriftController implements AntiDrift.Callback
 		final Vector3D loc = new Vector3D(x, y, z);
 		this.zratio = zratio;
 		this.zstep = zstep;
-		tp = 1;
+		this.tp = 1;
 
 		antiDrift = new DefaultAntiDrift();
 		gui = new AntiDriftAdjustWindow(x, y, z, theta, zratio);
@@ -153,7 +154,10 @@ public class AntiDriftController implements AntiDrift.Callback
 		if(null != outputDir)
 			antiDrift.writeDiff( getOutFile("initial"), antiDrift.getLastCorrection(), zratio, center );
 
-		ij.IJ.log( String.format( "X: %.2f, Y: %.2f, Z: %.2f", row.getX(), row.getY(), row.getZStartPosition() ) );
+		// Only in the production environment
+		if(null != row)
+			ij.IJ.log( String.format( "X: %.2f, Y: %.2f, Z: %.2f", row.getX(), row.getY(), row.getZStartPosition() ) );
+
 		// Process anti-drift
 		Vector3D init = antiDrift.finishStack();
 

--- a/src/main/java/spim/controller/AntiDriftController.java
+++ b/src/main/java/spim/controller/AntiDriftController.java
@@ -28,6 +28,7 @@ public class AntiDriftController implements AntiDrift.Callback
 	private File outputDir;
 	private Row row;
 	private boolean xInversed, yInversed, zInversed;
+	private boolean autoApplied = false;
 
 	/**
 	 * Instantiates a new AntiDriftController using primitive parameters
@@ -69,11 +70,13 @@ public class AntiDriftController implements AntiDrift.Callback
 	 * @param acqParams the acq params
 	 * @param acqRow the acq row
 	 */
-	public AntiDriftController(final File outputDir, final Params acqParams, final Row acqRow, final boolean xInversed, final boolean yInversed, final boolean zInversed)
+	public AntiDriftController(final File outputDir, final Params acqParams, final Row acqRow,
+			final boolean autoApplied, final boolean xInversed, final boolean yInversed, final boolean zInversed)
 	{
 		this( outputDir, acqRow.getX(), acqRow.getY(), acqRow.getZStartPosition(), acqRow.getTheta(),
 				acqRow.getZStepSize(), acqRow.getZStepSize() / acqParams.getCore().getPixelSizeUm() );
 
+		this.autoApplied = autoApplied;
 		this.row = acqRow;
 		this.xInversed = xInversed;
 		this.yInversed = yInversed;
@@ -88,9 +91,11 @@ public class AntiDriftController implements AntiDrift.Callback
 	 * @param acqRow the acq row
 	 * @return the AntiDriftController
 	 */
-	public static AntiDriftController newInstance(final File outputDir, final Params acqParams, final Row acqRow, final boolean xInversed, final boolean yInversed, final boolean zInversed)
+	public static AntiDriftController newInstance(final File outputDir, final Params acqParams, final Row acqRow,
+			final boolean autoApplied, final boolean xInversed, final boolean yInversed, final boolean zInversed)
 	{
-		return new AntiDriftController( outputDir, acqParams, acqRow, xInversed, yInversed, zInversed );
+		return new AntiDriftController( outputDir, acqParams, acqRow,
+				autoApplied, xInversed, yInversed, zInversed );
 	}
 
 	/**
@@ -178,6 +183,9 @@ public class AntiDriftController implements AntiDrift.Callback
 
 		gui.updateDiff();
 
+		if(autoApplied)
+			gui.autoApplyOffset();
+
 		// first = latest
 		antiDrift.setFirst( antiDrift.getLatest() );
 
@@ -210,7 +218,11 @@ public class AntiDriftController implements AntiDrift.Callback
 		}
 		else
 		{
-			ij.IJ.log(String.format("Use suggested w/ manual: using the adjusted correction: %s", updateOffset));
+			if(autoApplied)
+				ij.IJ.log(String.format("Use suggested value automatically: %s", updateOffset));
+			else
+				ij.IJ.log(String.format("Use suggested value with manual correction: %s", updateOffset));
+
 			ij.IJ.log(String.format("Returned Offset: %s", returnOffset ));
 		}
 

--- a/src/main/java/spim/gui/calibration/AntiDriftAdjustWindow.java
+++ b/src/main/java/spim/gui/calibration/AntiDriftAdjustWindow.java
@@ -156,11 +156,11 @@ public class AntiDriftAdjustWindow extends JFrame implements KeyListener
 				updateDiff();
 				break;
 			case KeyEvent.VK_LEFT:
-				offset = offset.add(new Vector3D((e.isShiftDown() ? 10 : 1), 0, 0));
+				offset = offset.add( new Vector3D( ( e.isShiftDown() ? 10 : 1 ), 0, 0 ) );
 				updateDiff();
 				break;
 			case KeyEvent.VK_RIGHT:
-				offset = offset.subtract(new Vector3D((e.isShiftDown() ? 10 : 1), 0, 0));
+				offset = offset.subtract( new Vector3D( ( e.isShiftDown() ? 10 : 1 ), 0, 0 ) );
 				updateDiff();
 				break;
 			case KeyEvent.VK_PAGE_UP:

--- a/src/main/java/spim/gui/calibration/AntiDriftAdjustWindow.java
+++ b/src/main/java/spim/gui/calibration/AntiDriftAdjustWindow.java
@@ -137,6 +137,12 @@ public class AntiDriftAdjustWindow extends JFrame implements KeyListener
 		setTitle(String.format("xyz: %.2f x %.2f x %.2f, theta: %.2f, timepoint %02d", loc.getX(), loc.getY(), loc.getZ(), theta, tp));
 	}
 
+	public void autoApplyOffset()
+	{
+		dispose();
+		callback.applyOffset(offset);
+	}
+
 	public void keyPressed(final KeyEvent e) {
 		switch (e.getKeyCode()) {
 			case KeyEvent.VK_ENTER:

--- a/src/main/java/spim/gui/input/LiveWindowMouseAdapter.java
+++ b/src/main/java/spim/gui/input/LiveWindowMouseAdapter.java
@@ -69,38 +69,38 @@ public class LiveWindowMouseAdapter extends MouseAdapter {
 		// First, check if MM has its claws in the target component (i.e. the live window).
 		// If so, ask the user if we want to a) remove MM's hooks, b) leave both hooks in, or c) don't hook.
 		// TODO: Should this check be external?
-		List<MouseListener> mls = Arrays.asList(to.getMouseListeners());
-		List<MouseMotionListener> mmls = Arrays.asList(to.getMouseMotionListeners());
-		List<MouseWheelListener> mwls = Arrays.asList(to.getMouseWheelListeners());
+		List<MouseListener> mouseListeners = Arrays.asList(to.getMouseListeners());
+		List<MouseMotionListener> mouseMotionListeners = Arrays.asList(to.getMouseMotionListeners());
+		List<MouseWheelListener> mouseWheelListeners = Arrays.asList(to.getMouseWheelListeners());
 
-		MouseListener ml = null;
-		MouseMotionListener mml = null;
-		MouseWheelListener mwl = null;
+		MouseListener mouseListener = null;
+		MouseMotionListener mouseMotionListener = null;
+		MouseWheelListener mouseWheelListener = null;
 
-		Iterator<MouseListener> mli = mls.iterator();
+		Iterator<MouseListener> mli = mouseListeners.iterator();
 		while(mli.hasNext())
-			if((ml = mli.next()) instanceof org.micromanager.navigation.CenterAndDragListener)
+			if((mouseListener = mli.next()) instanceof org.micromanager.navigation.CenterAndDragListener)
 				break;
 
-		Iterator<MouseMotionListener> mmli = mmls.iterator();
+		Iterator<MouseMotionListener> mmli = mouseMotionListeners.iterator();
 		while(mmli.hasNext())
-			if((mml = mmli.next()) instanceof org.micromanager.navigation.CenterAndDragListener)
+			if((mouseMotionListener = mmli.next()) instanceof org.micromanager.navigation.CenterAndDragListener)
 				break;
 
-		Iterator<MouseWheelListener> mwli = mwls.iterator();
+		Iterator<MouseWheelListener> mwli = mouseWheelListeners.iterator();
 		while(mwli.hasNext())
-			if((mwl = mwli.next()) instanceof org.micromanager.navigation.ZWheelListener)
+			if((mouseWheelListener = mwli.next()) instanceof org.micromanager.navigation.ZWheelListener)
 				break;
 
-		if(ml != null || mml != null || mwl != null) {
+		if(mouseListener != null || mouseMotionListener != null || mouseWheelListener != null) {
 			if(unhookMM < 0)
 				unhookMM = JOptionPane.showConfirmDialog(to, mmHooksWarnMsg, mmHooksWarnTitle, JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
 
 			if(unhookMM == JOptionPane.NO_OPTION) {
 				return false;
 			} else if(unhookMM == JOptionPane.YES_OPTION) {
-				mmMouseListener = (org.micromanager.navigation.CenterAndDragListener)(ml != null ? ml : mml);
-				mmMouseWheelListener = (org.micromanager.navigation.ZWheelListener)mwl;
+				mmMouseListener = (org.micromanager.navigation.CenterAndDragListener)(mouseListener != null ? mouseListener : mouseMotionListener);
+				mmMouseWheelListener = (org.micromanager.navigation.ZWheelListener)mouseWheelListener;
 
 				if(mmMouseListener != null)
 					mmMouseListener.stop();

--- a/src/main/java/spim/gui/input/LiveWindowMouseAdapter.java
+++ b/src/main/java/spim/gui/input/LiveWindowMouseAdapter.java
@@ -1,5 +1,6 @@
 package spim.gui.input;
 
+import ij.IJ;
 import ij.gui.Toolbar;
 
 import java.awt.Component;
@@ -229,7 +230,7 @@ public class LiveWindowMouseAdapter extends MouseAdapter {
 
 		if(!me.isAltDown()) {
 			Vector3D d = new Vector3D(drag.x * setup.getCore().getPixelSizeUm() * (me.isShiftDown() ? 2 : 1),
-									  drag.y * setup.getCore().getPixelSizeUm() * (me.isShiftDown() ? 2 : 1),
+									  drag.y * setup.getCore().getPixelSizeUm() * -(me.isShiftDown() ? 2 : 1),
 									  0);
 
 			setup.setPosition(stageStart.add(d), thetaStart);

--- a/src/main/java/spim/io/AsyncOutputHandler.java
+++ b/src/main/java/spim/io/AsyncOutputHandler.java
@@ -183,7 +183,8 @@ public class AsyncOutputHandler implements OutputHandler, UncaughtExceptionHandl
 	}
 
 	@Override
-	public void finalizeAcquisition() throws Exception {
+	public void finalizeAcquisition(boolean bSuccess) throws Exception {
+
 		if(rethrow != null)
 			throw rethrow;
 
@@ -210,7 +211,7 @@ public class AsyncOutputHandler implements OutputHandler, UncaughtExceptionHandl
 		}
 
 		synchronized(handler) {
-			handler.finalizeAcquisition();
+			handler.finalizeAcquisition(bSuccess);
 		}
 	}
 

--- a/src/main/java/spim/io/HDF5Generator.java
+++ b/src/main/java/spim/io/HDF5Generator.java
@@ -108,7 +108,6 @@ public class HDF5Generator
 		final OMETiffImageLoader imgLoader = new OMETiffImageLoader( path );
 		final SequenceDescriptionMinimal seq = new SequenceDescriptionMinimal( new TimePoints( timepoints ), setups, imgLoader, null );
 
-		imgLoader.setSetups( setups );
 		imgLoader.setSequenceDescription( seq );
 
 		final boolean isVirtual = false;

--- a/src/main/java/spim/io/HDF5Generator.java
+++ b/src/main/java/spim/io/HDF5Generator.java
@@ -22,6 +22,7 @@ import mpicbg.spim.data.registration.ViewRegistrations;
 import mpicbg.spim.data.sequence.Angle;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.Illumination;
 import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.TimePoints;
 import net.imglib2.FinalDimensions;
@@ -88,7 +89,14 @@ public class HDF5Generator
 
 			final BasicViewSetup setup = new BasicViewSetup( i, "" + i, size, voxelSize );
 			setup.setAttribute( new Angle( i ) );
+
+			// Illumination and Channel sizes are assumed to be 1
+			setup.setAttribute( new Illumination( 0 ) );
+			setup.setAttribute( new Channel( 0 ) );
+
 			setups.put( i, setup );
+
+
 
 			final ExportMipmapInfo autoMipmapSettings = ProposeMipmaps.proposeMipmaps( new BasicViewSetup( 0, "", size, voxelSize ) );
 			perSetupExportMipmapInfo.put( i, autoMipmapSettings );

--- a/src/main/java/spim/io/HDF5Generator.java
+++ b/src/main/java/spim/io/HDF5Generator.java
@@ -1,0 +1,209 @@
+package spim.io;
+
+import bdv.export.ExportMipmapInfo;
+import bdv.export.ProgressWriter;
+import bdv.export.ProposeMipmaps;
+import bdv.export.SubTaskProgressWriter;
+import bdv.export.WriteSequenceToHdf5;
+import bdv.img.hdf5.Hdf5ImageLoader;
+import bdv.img.hdf5.Partition;
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import ij.IJ;
+import ij.Prefs;
+import ij.io.LogStream;
+import loci.formats.ChannelSeparator;
+import loci.formats.FormatException;
+import loci.formats.IFormatReader;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
+import mpicbg.spim.data.sequence.Angle;
+import mpicbg.spim.data.sequence.Channel;
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.TimePoints;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import spim.io.imgloader.OMETiffImageLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by moon on 10/9/15.
+ */
+public class HDF5Generator
+{
+	private File outputDirectory;
+
+	public HDF5Generator(File outDir, File path, int angles, int numTimepoints, double pixelSizeUm, double zStepSize) throws IOException, FormatException
+	{
+		if(outDir == null || !outDir.exists() || !outDir.isDirectory())
+			throw new IllegalArgumentException("Null path specified: " + outDir.toString());
+
+		outputDirectory = outDir;
+
+		final IFormatReader r = new ChannelSeparator();
+
+		if ( !OMETiffImageLoader.createOMEXMLMetadata( r ) )
+		{
+			try
+			{
+				r.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+			return;
+		}
+
+		final String id = path.getAbsolutePath();
+		r.setId( id );
+
+		final HashMap< Integer, BasicViewSetup > setups = new HashMap< Integer, BasicViewSetup >( angles );
+		int planeSize = 0;
+		Map< Integer, ExportMipmapInfo > perSetupExportMipmapInfo = new HashMap< Integer, ExportMipmapInfo >();
+
+		final ArrayList< ViewRegistration > registrations = new ArrayList< ViewRegistration >();
+
+		for(int i = 0; i < angles; i++)
+		{
+			r.setSeries(i);
+			final int width = r.getSizeX();
+			final int height = r.getSizeY();
+			final int depth = r.getSizeZ();
+			planeSize = width * height * r.getBitsPerPixel();
+
+			String punit = "um";
+			final FinalVoxelDimensions voxelSize = new FinalVoxelDimensions( punit, pixelSizeUm, pixelSizeUm, zStepSize);
+			final FinalDimensions size = new FinalDimensions( new int[] { width, height, depth } );
+
+			final BasicViewSetup setup = new BasicViewSetup( i, "" + i, size, voxelSize );
+			setup.setAttribute( new Angle( i ) );
+			setups.put( i, setup );
+
+			final ExportMipmapInfo autoMipmapSettings = ProposeMipmaps.proposeMipmaps( new BasicViewSetup( 0, "", size, voxelSize ) );
+			perSetupExportMipmapInfo.put( i, autoMipmapSettings );
+
+			// create SourceTransform from the images calibration
+			final AffineTransform3D sourceTransform = new AffineTransform3D();
+			sourceTransform.set( pixelSizeUm, 0, 0, 0, 0, pixelSizeUm, 0, 0, 0, 0, zStepSize, 0 );
+
+			for ( int t = 0; t < numTimepoints; ++t )
+				registrations.add( new ViewRegistration( t, i, sourceTransform ) );
+		}
+
+		final ArrayList< TimePoint > timepoints = new ArrayList< TimePoint >( numTimepoints );
+		for ( int t = 0; t < numTimepoints; ++t )
+			timepoints.add( new TimePoint( t ) );
+
+		final OMETiffImageLoader imgLoader = new OMETiffImageLoader( path );
+		final SequenceDescriptionMinimal seq = new SequenceDescriptionMinimal( new TimePoints( timepoints ), setups, imgLoader, null );
+
+		imgLoader.setSetups( setups );
+		imgLoader.setSequenceDescription( seq );
+
+		final boolean isVirtual = false;
+		final long planeSizeInBytes = planeSize;
+		final long ijMaxMemory = IJ.maxMemory();
+		final int numCellCreatorThreads = Math.max( 1, Prefs.getThreads() );
+		final WriteSequenceToHdf5.LoopbackHeuristic loopbackHeuristic = new WriteSequenceToHdf5.LoopbackHeuristic()
+		{
+			@Override
+			public boolean decide( final RandomAccessibleInterval< ? > originalImg, final int[] factorsToOriginalImg, final int previousLevel, final int[] factorsToPreviousLevel, final int[] chunkSize )
+			{
+				if ( previousLevel < 0 )
+					return false;
+
+				if ( WriteSequenceToHdf5.numElements( factorsToOriginalImg ) / WriteSequenceToHdf5.numElements( factorsToPreviousLevel ) >= 8 )
+					return true;
+
+				if ( isVirtual )
+				{
+					final long requiredCacheSize = planeSizeInBytes * factorsToOriginalImg[ 2 ] * chunkSize[ 2 ];
+					if ( requiredCacheSize > ijMaxMemory / 4 )
+						return true;
+				}
+
+				return false;
+			}
+		};
+
+		final WriteSequenceToHdf5.AfterEachPlane afterEachPlane = new WriteSequenceToHdf5.AfterEachPlane()
+		{
+			@Override
+			public void afterEachPlane( final boolean usedLoopBack )
+			{
+				if ( !usedLoopBack && isVirtual )
+				{
+					final long free = Runtime.getRuntime().freeMemory();
+					final long total = Runtime.getRuntime().totalMemory();
+					final long max = Runtime.getRuntime().maxMemory();
+					final long actuallyFree = max - total + free;
+				}
+			}
+
+		};
+
+		ProgressWriterIJ progressWriter = new ProgressWriterIJ();
+		final ArrayList< Partition > partitions = null;
+		WriteSequenceToHdf5.writeHdf5File( seq, perSetupExportMipmapInfo, false, new File(outDir + "/dataset.h5"), loopbackHeuristic, afterEachPlane, numCellCreatorThreads, new SubTaskProgressWriter( progressWriter, 0, 0.95 ) );
+
+		// write xml sequence description
+		final Hdf5ImageLoader hdf5Loader = new Hdf5ImageLoader( new File(outDir + "/dataset.h5"), partitions, null, false );
+		final SequenceDescriptionMinimal seqh5 = new SequenceDescriptionMinimal( seq, hdf5Loader );
+
+		final File basePath = outputDirectory;
+		final SpimDataMinimal spimData = new SpimDataMinimal( basePath, seqh5, new ViewRegistrations( registrations ) );
+
+		try
+		{
+			new XmlIoSpimDataMinimal().save( spimData, outDir + "/dataset.xml" );
+		}
+		catch ( final Exception e )
+		{
+			throw new RuntimeException( e );
+		}
+
+		progressWriter.out().println( "done" );
+	}
+
+	private class ProgressWriterIJ implements ProgressWriter
+	{
+		protected final PrintStream out;
+
+		protected final PrintStream err;
+
+		public ProgressWriterIJ()
+		{
+			out = new LogStream();
+			err = new LogStream();
+		}
+
+		@Override
+		public PrintStream out()
+		{
+			return out;
+		}
+
+		@Override
+		public PrintStream err()
+		{
+			return err;
+		}
+
+		@Override
+		public void setProgress( final double completionRatio )
+		{
+			IJ.showProgress( completionRatio );
+		}
+	}
+}

--- a/src/main/java/spim/io/HDF5Generator.java
+++ b/src/main/java/spim/io/HDF5Generator.java
@@ -43,7 +43,7 @@ public class HDF5Generator
 {
 	private File outputDirectory;
 
-	public HDF5Generator(File outDir, File path, int angles, int numTimepoints, double pixelSizeUm, double zStepSize) throws IOException, FormatException
+	public HDF5Generator(File outDir, File path, int angles, int numTimepoints, double pixelSizeUm, double[] zStepSize) throws IOException, FormatException
 	{
 		if(outDir == null || !outDir.exists() || !outDir.isDirectory())
 			throw new IllegalArgumentException("Null path specified: " + outDir.toString());
@@ -83,7 +83,7 @@ public class HDF5Generator
 			planeSize = width * height * r.getBitsPerPixel();
 
 			String punit = "um";
-			final FinalVoxelDimensions voxelSize = new FinalVoxelDimensions( punit, pixelSizeUm, pixelSizeUm, zStepSize);
+			final FinalVoxelDimensions voxelSize = new FinalVoxelDimensions( punit, pixelSizeUm, pixelSizeUm, zStepSize[i] );
 			final FinalDimensions size = new FinalDimensions( new int[] { width, height, depth } );
 
 			final BasicViewSetup setup = new BasicViewSetup( i, "" + i, size, voxelSize );
@@ -95,7 +95,7 @@ public class HDF5Generator
 
 			// create SourceTransform from the images calibration
 			final AffineTransform3D sourceTransform = new AffineTransform3D();
-			sourceTransform.set( pixelSizeUm, 0, 0, 0, 0, pixelSizeUm, 0, 0, 0, 0, zStepSize, 0 );
+			sourceTransform.set( pixelSizeUm, 0, 0, 0, 0, pixelSizeUm, 0, 0, 0, 0, zStepSize[i], 0 );
 
 			for ( int t = 0; t < numTimepoints; ++t )
 				registrations.add( new ViewRegistration( t, i, sourceTransform ) );

--- a/src/main/java/spim/io/IndividualImagesHandler.java
+++ b/src/main/java/spim/io/IndividualImagesHandler.java
@@ -74,7 +74,7 @@ public class IndividualImagesHandler implements OutputHandler
 	}
 
 	@Override
-	public void finalizeAcquisition() throws Exception {
+	public void finalizeAcquisition(boolean bSuccess) throws Exception {
 		// Nothing to do.
 	}
 

--- a/src/main/java/spim/io/OMETIFFHandler.java
+++ b/src/main/java/spim/io/OMETIFFHandler.java
@@ -12,6 +12,7 @@ import loci.formats.IFormatWriter;
 import loci.formats.ImageWriter;
 import loci.formats.MetadataTools;
 import loci.formats.meta.IMetadata;
+import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
 import mmcorej.CMMCore;
 import ome.units.UNITS;
@@ -107,6 +108,10 @@ public class OMETIFFHandler implements OutputHandler
 			}
 
 			writer = new ImageWriter().getWriter(makeFilename(filenamePrefix, 0, 0, 0, false));
+			if (writer instanceof OMETiffWriter ) {
+				ij.IJ.log("calling setBigTiff(true)");
+				((OMETiffWriter) writer).setBigTiff(true);
+			}
 
 			writer.setWriteSequentially(true);
 			writer.setMetadataRetrieve(meta);

--- a/src/main/java/spim/io/OMETIFFHandler.java
+++ b/src/main/java/spim/io/OMETIFFHandler.java
@@ -130,7 +130,7 @@ public class OMETIFFHandler implements OutputHandler
 			posString=String.format("Pos%02d_", posIndex);
 		else
 			posString="";
-		return String.format(filenamePrefix+"TL%02d_"+posString+"Angle%01d.ome.tiff", (timepoint + 1), angleIndex);
+		return String.format(filenamePrefix+"TL%02d_"+posString+"Angle%01d.ome.tiff", timepoint, angleIndex);
 	}
 
 	private void openWriter(int angleIndex, int timepoint) throws Exception {

--- a/src/main/java/spim/io/OMETIFFHandler.java
+++ b/src/main/java/spim/io/OMETIFFHandler.java
@@ -216,7 +216,7 @@ public class OMETIFFHandler implements OutputHandler, Thread.UncaughtExceptionHa
 	}
 
 	@Override
-	public void finalizeAcquisition() throws Exception {
+	public void finalizeAcquisition(boolean bSuccess) throws Exception {
 
 		final File firstFile = new File(outputDirectory, meta.getUUIDFileName(0, 0));
 
@@ -227,7 +227,7 @@ public class OMETIFFHandler implements OutputHandler, Thread.UncaughtExceptionHa
 
 		writer = null;
 
-		if (exportToHDF5)
+		if (bSuccess && exportToHDF5)
 		{
 			hdf5ResaveThread = new Thread( new Runnable() {
 				@Override

--- a/src/main/java/spim/io/OutputAsStackHandler.java
+++ b/src/main/java/spim/io/OutputAsStackHandler.java
@@ -24,7 +24,7 @@ public class OutputAsStackHandler implements OutputHandler
 	}
 
 	@Override
-	public void finalizeAcquisition() throws Exception {
+	public void finalizeAcquisition(boolean bSuccess) throws Exception {
 		img = new ImagePlus("SimpleOutput", stack);
 	}
 

--- a/src/main/java/spim/io/OutputHandler.java
+++ b/src/main/java/spim/io/OutputHandler.java
@@ -51,8 +51,9 @@ public interface OutputHandler
 	 * the handler should be in a state where it can accept new slices as an
 	 * entirely different acquisition.
 	 *
+	 * @param b true if the process is finalized successfully. Otherwise, false for abortion.
 	 * @throws Exception
 	 */
-	public abstract void finalizeAcquisition() throws Exception;
+	public abstract void finalizeAcquisition(boolean b) throws Exception;
 
 }

--- a/src/main/java/spim/io/imgloader/AbstractImgFactoryImgLoader.java
+++ b/src/main/java/spim/io/imgloader/AbstractImgFactoryImgLoader.java
@@ -1,0 +1,12 @@
+package spim.io.imgloader;
+
+import net.imglib2.img.ImgFactory;
+import net.imglib2.type.NativeType;
+
+public abstract class AbstractImgFactoryImgLoader extends AbstractImgLoader
+{
+	protected ImgFactory< ? extends NativeType< ? > > imgFactory = null;
+
+	public ImgFactory< ? extends NativeType< ? > > getImgFactory() { return imgFactory; }
+	public void setImgFactory( final ImgFactory< ? extends NativeType< ? > > imgFactory ) { this.imgFactory = imgFactory; }
+}

--- a/src/main/java/spim/io/imgloader/AbstractImgLoader.java
+++ b/src/main/java/spim/io/imgloader/AbstractImgLoader.java
@@ -1,0 +1,162 @@
+package spim.io.imgloader;
+
+import mpicbg.spim.data.SpimData;
+import mpicbg.spim.data.legacy.LegacyImgLoader;
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewSetup;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+
+import java.util.HashMap;
+import java.util.List;
+
+public abstract class AbstractImgLoader implements LegacyImgLoader< UnsignedShortType >
+{
+	private final HashMap< ViewId, Pair< Dimensions, VoxelDimensions > > imageMetaDataCache;
+	private final HashMap< Integer, ViewId > viewIdLookUp;
+
+	protected AbstractImgLoader()
+	{
+		imageMetaDataCache = new HashMap< ViewId, Pair< Dimensions, VoxelDimensions > >();
+		viewIdLookUp = new HashMap< Integer, ViewId >();
+	}
+
+	/**
+	 * Updates the cached imageMetaData
+	 */
+	protected void updateMetaDataCache( final ViewId viewId,
+			final int w, final int h, final int d,
+			final double calX, final double calY, final double calZ )
+	{
+		imageMetaDataCache.put( viewId, new ValuePair< Dimensions, VoxelDimensions >(
+				new FinalDimensions( new long[] { w, h, d } ),
+				new FinalVoxelDimensions( "", calX, calY, calZ ) ) );
+
+		// links the viewSetupId to the last added viewId, overwrites earlier entries
+		viewIdLookUp.put( viewId.getViewSetupId(), viewId );
+	}
+
+	/**
+	 * Loads only the metadata from the image, should call updateMetaDataCache( ... )
+	 * @param view
+	 */
+	protected abstract void loadMetaData( final ViewId view );
+
+	@Override
+	public Dimensions getImageSize( final ViewId view )
+	{
+		// if there is no data for the viewId
+		if ( !imageMetaDataCache.containsKey( view ) )
+		{
+			// check if the data is present for the same viewsetup of another timepoint
+			if ( !viewIdLookUp.containsKey( view.getViewSetupId() ) )
+				loadMetaData( view );
+			else
+				return imageMetaDataCache.get( viewIdLookUp.get( view.getViewSetupId() ) ).getA();
+		}
+		return imageMetaDataCache.get( view ).getA();
+	}
+
+	@Override
+	public VoxelDimensions getVoxelSize( final ViewId view )
+	{
+		// if there is no data for the viewId
+		if ( !imageMetaDataCache.containsKey( view ) )
+		{
+			// check if the data is present for the same viewsetup of another timepoint
+			if ( !viewIdLookUp.containsKey( view.getViewSetupId() ) )
+				loadMetaData( view );
+			else
+				return imageMetaDataCache.get( viewIdLookUp.get( view.getViewSetupId() ) ).getB();
+		}
+		return imageMetaDataCache.get( view ).getB();
+	}
+
+	@Override
+	public UnsignedShortType getImageType()
+	{
+		return new UnsignedShortType();
+	}
+
+	/**
+	 * Updates the ViewSetups using the imageMetaDataCache
+	 *
+	 * @param data - the {@link SpimData} object that contains all {@link ViewSetup}s can could be potentially updated
+	 * @param forceUpdate - overwrite the data if it is already present
+	 */
+	public void updateXMLMetaData( final SpimData data, final boolean forceUpdate )
+	{
+		updateXMLMetaData( data.getSequenceDescription().getViewSetupsOrdered(), forceUpdate );
+	}
+
+	/**
+	 * Updates a list of ViewSetups using the imageMetaDataCache
+	 *
+	 * @param setups - a list of {@link ViewSetup}s can could be potentially updated
+	 * @param forceUpdate - overwrite the data if it is already present
+	 */
+	public void updateXMLMetaData( final List< ? extends ViewSetup > setups, final boolean forceUpdate )
+	{
+		for ( final ViewSetup setup : setups )
+			updateXMLMetaData( setup, forceUpdate );
+	}
+
+	/**
+	 * Updates one specific ViewSetup using the imageMetaDataCache
+	 *
+	 * @param setup - {@link ViewSetup}s that can potentially be updated if it is in the cache
+	 * @param forceUpdate - overwrite the data if it is already present
+	 * @return true if something was updated, false if it was not in the cache or if could have been updated but was already there
+	 */
+	public boolean updateXMLMetaData( final ViewSetup setup, final boolean forceUpdate )
+	{
+		boolean updated = false;
+
+		if ( viewIdLookUp.containsKey( setup.getId() ) )
+		{
+			// look up the metadata using the ViewId linked by the ViewSetupId
+			final Pair< Dimensions, VoxelDimensions > metaData = imageMetaDataCache.get( viewIdLookUp.get( setup.getId() ) );
+
+			if ( !setup.hasSize() || forceUpdate )
+			{
+				setup.setSize( metaData.getA() );
+				updated = true;
+			}
+
+			if ( !setup.hasVoxelSize() || forceUpdate )
+			{
+				setup.setVoxelSize( metaData.getB() );
+				updated = true;
+			}
+		}
+
+		return updated;
+	}
+
+	protected static final void normalize( final Img< FloatType > img )
+	{
+		float min = Float.MAX_VALUE;
+		float max = -Float.MAX_VALUE;
+
+		for ( final FloatType t : img )
+		{
+			final float v = t.get();
+
+			if ( v < min )
+				min = v;
+
+			if ( v > max )
+				max = v;
+		}
+
+		for ( final FloatType t : img )
+			t.set( ( t.get() - min ) / ( max - min ) );
+	}
+}

--- a/src/main/java/spim/io/imgloader/CalibratedImg.java
+++ b/src/main/java/spim/io/imgloader/CalibratedImg.java
@@ -1,0 +1,28 @@
+package spim.io.imgloader;
+
+import net.imglib2.img.Img;
+
+public class CalibratedImg< T >
+{
+	final Img< T > image;
+	final double calX, calY, calZ;
+
+	public CalibratedImg( final Img< T > image )
+	{
+		this.image = image;
+		this.calX = this.calY = this.calZ = -1;
+	}
+
+	public CalibratedImg( final Img< T > image, final double calX, final double calY, final double calZ )
+	{
+		this.image = image;
+		this.calX = calX;
+		this.calY = calY;
+		this.calZ = calZ;
+	}
+
+	public Img< T > getImg(){ return image; }
+	public double getCalX() { return calX; }
+	public double getCalY() { return calY; }
+	public double getCalZ() { return calZ; }
+}

--- a/src/main/java/spim/io/imgloader/Calibration.java
+++ b/src/main/java/spim/io/imgloader/Calibration.java
@@ -1,0 +1,25 @@
+package spim.io.imgloader;
+
+
+public class Calibration
+{
+	final int w, h, d;
+	final double calX, calY, calZ;
+
+	public Calibration( final int w, final int h, final int d, final double calX, final double calY, final double calZ )
+	{
+		this.w = w;
+		this.h = h;
+		this.d = d;
+		this.calX = calX;
+		this.calY = calY;
+		this.calZ = calZ;
+	}
+
+	public double getCalX() { return calX; }
+	public double getCalY() { return calY; }
+	public double getCalZ() { return calZ; }
+	public int getWidth() { return w; }
+	public int getHeight() { return h; }
+	public int getDepth() { return d; }
+}

--- a/src/main/java/spim/io/imgloader/LegacyOMETiffImageLoader.java
+++ b/src/main/java/spim/io/imgloader/LegacyOMETiffImageLoader.java
@@ -1,0 +1,396 @@
+package spim.io.imgloader;
+
+import bdv.spimdata.SequenceDescriptionMinimal;
+import ij.IJ;
+import loci.formats.ChannelSeparator;
+import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.meta.MetadataRetrieve;
+import mpicbg.spim.data.generic.sequence.BasicViewDescription;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.sequence.Angle;
+import mpicbg.spim.data.sequence.Channel;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.ViewId;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+import ome.units.quantity.Length;
+import org.micromanager.utils.ReportingUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Created by moon on 12/8/15.
+ */
+public class LegacyOMETiffImageLoader extends LegacyStackImgLoader
+{
+	private final File file;
+
+	public LegacyOMETiffImageLoader( final File file )
+	{
+		super(file, new ArrayImgFactory< UnsignedShortType >(), null);
+		this.file = file;
+	}
+
+	public void setSequenceDescription( SequenceDescriptionMinimal sequenceDescriptionMinimal )
+	{
+		this.sequenceDescription = sequenceDescriptionMinimal;
+	}
+
+	@Override public RandomAccessibleInterval< UnsignedShortType > getImage( ViewId view )
+	{
+		try
+		{
+			CalibratedImg< UnsignedShortType > img = openLOCI( file, new UnsignedShortType(), view );
+			return img.getImg();
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	protected < T extends RealType< T > & NativeType< T > > CalibratedImg< T > openLOCI( final File path, final T type, final ViewId view ) throws Exception
+	{
+		BasicViewDescription< ? > viewDescription = sequenceDescription.getViewDescriptions().get( view );
+
+		final IFormatReader r = new ChannelSeparator();
+
+		if ( !OMETiffImageLoader.createOMEXMLMetadata( r ) )
+		{
+			try
+			{
+				r.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		final String id = path.getAbsolutePath();
+
+		r.setId( id );
+		final Angle angle = getAngle( viewDescription );
+		r.setSeries( angle.getId() );
+
+		final boolean isLittleEndian = r.isLittleEndian();
+		final int width = r.getSizeX();
+		final int height = r.getSizeY();
+		final int depth = r.getSizeZ();
+		final int timepoints = r.getSizeT();
+		final int channels = r.getSizeC();
+		final int pixelType = r.getPixelType();
+		final int bytesPerPixel = FormatTools.getBytesPerPixel( pixelType );
+		final String pixelTypeString = FormatTools.getPixelTypeString( pixelType );
+
+		final TimePoint timePoint = viewDescription.getTimePoint();
+		int t = timePoint.getId();
+
+		//		final Channel channel = getChannel( viewDescription );
+		//		int c = channel.getId();
+		int c = 0;
+
+		final MetadataRetrieve retrieve = (MetadataRetrieve)r.getMetadataStore();
+
+		double calX, calY, calZ;
+
+		try
+		{
+			float cal = retrieve.getPixelsPhysicalSizeX( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calX = cal;
+
+			cal = retrieve.getPixelsPhysicalSizeY( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calY = cal;
+
+			cal = retrieve.getPixelsPhysicalSizeZ( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calZ = cal;
+		}
+		catch ( Exception e )
+		{
+			calX = calY = calZ = 1;
+		}
+
+		final Img< T > img = instantiateImg( new long[] { width, height, depth }, type );
+
+		if ( img == null )
+		{
+			r.close();
+			throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + path + "', most likely out of memory." );
+		}
+		else
+			ReportingUtils.logMessage( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + width + "x" + height + "x" + depth + " ch=" + c + " tp=" + t + " type=" + pixelTypeString + " image=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
+
+		final byte[] b = new byte[width * height * bytesPerPixel];
+
+		final int planeX = 0;
+		final int planeY = 1;
+
+		for ( int z = 0; z < depth; ++z )
+		{
+			IJ.showProgress( ( double ) z / ( double ) depth );
+
+			final Cursor< T > cursor = Views.iterable( Views.hyperSlice( img, 2, z ) ).localizingCursor();
+
+			r.openBytes( r.getIndex( z, c, t ), b );
+
+			if ( pixelType == FormatTools.UINT8 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( b[ cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ] & 0xff );
+				}
+			}
+			else if ( pixelType == FormatTools.UINT16 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getShortValueInt( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.INT16 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getShortValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.UINT32 )
+			{
+				//TODO: Untested
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getIntValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.FLOAT )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getFloatValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
+				}
+			}
+		}
+
+		r.close();
+
+		IJ.showProgress( 1 );
+
+		return new CalibratedImg<T>( img, calX, calY, calZ );
+	}
+
+	protected static final float getFloatValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return Float.intBitsToFloat( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
+		else
+			return Float.intBitsToFloat( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
+	}
+
+	protected static final int getIntValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return ( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
+		else
+			return ( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
+	}
+
+	protected static final short getShortValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		return (short)getShortValueInt( b, i, isLittleEndian );
+	}
+
+	protected static final int getShortValueInt( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return ((((b[i+1] & 0xff) << 8)) + (b[i] & 0xff));
+		else
+			return ((((b[i] & 0xff) << 8)) + (b[i+1] & 0xff));
+	}
+
+	protected static Angle getAngle( final BasicViewDescription< ? > vd )
+	{
+		final BasicViewSetup vs = vd.getViewSetup();
+		final Angle angle = vs.getAttribute( Angle.class );
+
+		if ( angle == null )
+			throw new RuntimeException( "This XML does not have the 'Angle' attribute for their ViewSetup. Cannot continue." );
+
+		return angle;
+	}
+
+	protected static Channel getChannel( final BasicViewDescription< ? > vd )
+	{
+		final BasicViewSetup vs = vd.getViewSetup();
+		final Channel channel = vs.getAttribute( Channel.class );
+
+		if ( channel == null )
+			throw new RuntimeException( "This XML does not have the 'Channel' attribute for their ViewSetup. Cannot continue." );
+
+		return channel;
+	}
+
+	@Override protected void loadMetaData( ViewId view )
+	{
+		BasicViewDescription< ? > viewDescription = sequenceDescription.getViewDescriptions().get( view );
+
+		final IFormatReader r = new ChannelSeparator();
+
+		if ( !OMETiffImageLoader.createOMEXMLMetadata( r ) )
+		{
+			try
+			{
+				r.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+			return;
+		}
+
+		try
+		{
+			r.setId( file.getAbsolutePath() );
+
+			final Angle angle = getAngle( viewDescription );
+			r.setSeries( angle.getId() );
+
+			final MetadataRetrieve retrieve = (MetadataRetrieve)r.getMetadataStore();
+
+			float cal = 0;
+
+			Length f = retrieve.getPixelsPhysicalSizeX( 0 );
+			if ( f != null )
+				cal = f.value().floatValue();
+
+			if ( cal == 0 )
+			{
+				cal = 1;
+				ij.IJ.log( "StackListLOCI: Warning, calibration for dimension X seems corrupted, setting to 1." );
+			}
+			final double calX = cal;
+
+			f = retrieve.getPixelsPhysicalSizeY( 0 );
+			if ( f != null )
+				cal = f.value().floatValue();
+
+			if ( cal == 0 )
+			{
+				cal = 1;
+				ij.IJ.log( "StackListLOCI: Warning, calibration for dimension Y seems corrupted, setting to 1." );
+			}
+			final double calY = cal;
+
+			f = retrieve.getPixelsPhysicalSizeZ( 0 );
+			if ( f != null )
+				cal = f.value().floatValue();
+
+			if ( cal == 0 )
+			{
+				cal = 1;
+				ij.IJ.log( "StackListLOCI: Warning, calibration for dimension Z seems corrupted, setting to 1." );
+			}
+			final double calZ = cal;
+
+			ij.IJ.log( "Image stack size of first stack: " + r.getSizeX() + "x" + r.getSizeY() + "x" + r.getSizeZ() );
+
+			final Calibration calibration = new Calibration( r.getSizeX(), r.getSizeY(), r.getSizeZ(), calX, calY, calZ );
+
+			if ( calibration != null )
+			{
+				// update the MetaDataCache of the AbstractImgLoader
+				// this does not update the XML ViewSetup but has to be called explicitly before saving
+				updateMetaDataCache( view, calibration.getWidth(), calibration.getHeight(), calibration.getDepth(),
+						calibration.getCalX(), calibration.getCalY(), calibration.getCalZ() );
+			}
+
+			r.close();
+		}
+		catch ( Exception e)
+		{
+			ij.IJ.log( "Could not open file: '" + file.getAbsolutePath() + "'" );
+			e.printStackTrace();
+		}
+	}
+
+	@Override public UnsignedShortType getImageType()
+	{
+		return new UnsignedShortType();
+	}
+
+	@Override public RandomAccessibleInterval< FloatType > getFloatImage( ViewId view, boolean normalize )
+	{
+		if ( file == null )
+			throw new RuntimeException( "Could not find file '" + file + "'." );
+
+		try
+		{
+			final CalibratedImg< FloatType > img = openLOCI( file, new FloatType(), view );
+
+			if ( img == null )
+				throw new RuntimeException( "Could not load '" + file + "'" );
+
+			if ( normalize )
+			{
+				float min = Float.MAX_VALUE;
+				float max = -Float.MAX_VALUE;
+
+				for ( final FloatType t : img.getImg() )
+				{
+					final float v = t.get();
+
+					if ( v < min )
+						min = v;
+
+					if ( v > max )
+						max = v;
+				}
+
+				for ( final FloatType t : img.getImg() )
+					t.set( ( t.get() - min ) / ( max - min ) );
+
+			}
+
+			// update the MetaDataCache of the AbstractImgLoader
+			// this does not update the XML ViewSetup but has to be called explicitly before saving
+			updateMetaDataCache( view, (int)img.getImg().dimension( 0 ),
+					(int)img.getImg().dimension( 1 ), (int)img.getImg().dimension( 2 ),
+					img.getCalX(), img.getCalY(), img.getCalZ() );
+
+			return img.getImg();
+		}
+		catch ( Exception e )
+		{
+			throw new RuntimeException( "Could not load '" + file + "':\n" + e );
+		}
+	}
+}

--- a/src/main/java/spim/io/imgloader/LegacyStackImgLoader.java
+++ b/src/main/java/spim/io/imgloader/LegacyStackImgLoader.java
@@ -1,0 +1,61 @@
+package spim.io.imgloader;
+
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.NativeType;
+
+import java.io.File;
+
+public abstract class LegacyStackImgLoader extends AbstractImgFactoryImgLoader
+{
+	protected File path = null;
+
+	protected AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
+
+	protected < T extends NativeType< T > > Img< T > instantiateImg( final long[] dim, final T type )
+	{
+		Img< T > img;
+
+		try
+		{
+			img = getImgFactory().imgFactory( type ).create( dim, type );
+		}
+		catch ( Exception e1 )
+		{
+			try
+			{
+				img = new CellImgFactory< T >( 256 ).create( dim, type );
+			}
+			catch ( Exception e2 )
+			{
+				img = null;
+			}
+		}
+
+		return img;
+	}
+
+	/**
+	 * For a local initialization without the XML
+	 *
+	 * @param path
+	 * @param imgFactory
+	 */
+	public LegacyStackImgLoader(
+			final File path, final ImgFactory< ? extends NativeType< ? > > imgFactory,
+			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
+	{
+		super();
+		this.path = path;
+		this.sequenceDescription = sequenceDescription;
+
+		this.init( imgFactory );
+	}
+
+	protected void init( final ImgFactory< ? extends NativeType< ? > > imgFactory )
+	{
+		setImgFactory( imgFactory );
+	}
+}

--- a/src/main/java/spim/io/imgloader/OMETiffImageLoader.java
+++ b/src/main/java/spim/io/imgloader/OMETiffImageLoader.java
@@ -17,18 +17,23 @@ import loci.formats.services.OMEXMLService;
 import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.legacy.LegacyImgLoader;
+import mpicbg.spim.data.legacy.LegacyImgLoaderWrapper;
 import mpicbg.spim.data.sequence.Angle;
 import mpicbg.spim.data.sequence.Channel;
 import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
+import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.Cursor;
+import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.Views;
 import org.micromanager.utils.ReportingUtils;
 
@@ -40,41 +45,15 @@ import java.util.HashMap;
 /**
  * Created by moon on 10/9/15.
  */
-public class OMETiffImageLoader implements BasicImgLoader< UnsignedShortType >
+public class OMETiffImageLoader extends LegacyImgLoaderWrapper
 {
-	private final File file;
-
-	private HashMap< Integer, BasicViewSetup > setups;
-
-	private SequenceDescriptionMinimal sequenceDescriptionMinimal;
+	final LegacyOMETiffImageLoader legacyOMETiffImageLoader;
 
 	public OMETiffImageLoader( final File file )
 	{
-		this.file = file;
-	}
+		super( new LegacyOMETiffImageLoader( file ) );
 
-	public void setSetups( HashMap< Integer, BasicViewSetup > setups )
-	{
-		this.setups = setups;
-	}
-
-	public void setSequenceDescription( SequenceDescriptionMinimal sequenceDescriptionMinimal )
-	{
-		this.sequenceDescriptionMinimal = sequenceDescriptionMinimal;
-	}
-
-	@Override public RandomAccessibleInterval< UnsignedShortType > getImage( ViewId view )
-	{
-		Img< UnsignedShortType > img = null;
-		try
-		{
-			img = openLOCI( file, new UnsignedShortType(), view );
-		}
-		catch ( Exception e )
-		{
-			e.printStackTrace();
-		}
-		return img;
+		legacyOMETiffImageLoader = ( LegacyOMETiffImageLoader ) super.legacyImgLoader;
 	}
 
 	public static boolean createOMEXMLMetadata( final IFormatReader r )
@@ -84,14 +63,14 @@ public class OMETiffImageLoader implements BasicImgLoader< UnsignedShortType >
 			final ServiceFactory serviceFactory = new ServiceFactory();
 			final OMEXMLService service = serviceFactory.getInstance( OMEXMLService.class );
 			final IMetadata omexmlMeta = service.createOMEXMLMetadata();
-			r.setMetadataStore(omexmlMeta);
+			r.setMetadataStore( omexmlMeta );
 		}
-		catch (final ServiceException e)
+		catch ( final ServiceException e )
 		{
 			e.printStackTrace();
 			return false;
 		}
-		catch (final DependencyException e)
+		catch ( final DependencyException e )
 		{
 			e.printStackTrace();
 			return false;
@@ -100,210 +79,8 @@ public class OMETiffImageLoader implements BasicImgLoader< UnsignedShortType >
 		return true;
 	}
 
-
-	protected < T extends RealType< T > & NativeType< T > > Img< T > openLOCI( final File path, final T type, final ViewId view ) throws Exception
+	public void setSequenceDescription( SequenceDescriptionMinimal sequenceDescriptionMinimal )
 	{
-		BasicViewDescription< ? > viewDescription = sequenceDescriptionMinimal.getViewDescriptions().get( view );
-
-		final IFormatReader r = new ChannelSeparator();
-
-		if ( !createOMEXMLMetadata( r ) )
-		{
-			try
-			{
-				r.close();
-			}
-			catch (IOException e)
-			{
-				e.printStackTrace();
-			}
-			return null;
-		}
-
-		final String id = path.getAbsolutePath();
-
-		r.setId( id );
-		final Angle angle = getAngle( viewDescription );
-		r.setSeries( angle.getId() );
-
-		final boolean isLittleEndian = r.isLittleEndian();
-		final int width = r.getSizeX();
-		final int height = r.getSizeY();
-		final int depth = r.getSizeZ();
-		final int timepoints = r.getSizeT();
-		final int channels = r.getSizeC();
-		final int pixelType = r.getPixelType();
-		final int bytesPerPixel = FormatTools.getBytesPerPixel( pixelType );
-		final String pixelTypeString = FormatTools.getPixelTypeString( pixelType );
-
-		final TimePoint timePoint = viewDescription.getTimePoint();
-		int t = timePoint.getId();
-
-//		final Channel channel = getChannel( viewDescription );
-//		int c = channel.getId();
-		int c = 0;
-
-		final MetadataRetrieve retrieve = (MetadataRetrieve)r.getMetadataStore();
-
-		double calX, calY, calZ;
-
-		try
-		{
-			float cal = retrieve.getPixelsPhysicalSizeX( 0 ).value().floatValue();
-			if ( cal == 0 )
-			{
-				cal = 1;
-			}
-			calX = cal;
-
-			cal = retrieve.getPixelsPhysicalSizeY( 0 ).value().floatValue();
-			if ( cal == 0 )
-			{
-				cal = 1;
-			}
-			calY = cal;
-
-			cal = retrieve.getPixelsPhysicalSizeZ( 0 ).value().floatValue();
-			if ( cal == 0 )
-			{
-				cal = 1;
-			}
-			calZ = cal;
-		}
-		catch ( Exception e )
-		{
-			calX = calY = calZ = 1;
-		}
-
-		final Img< T > img;
-
-		ArrayImgFactory factory = new ArrayImgFactory< UnsignedShortType >();
-		img = factory.create( new long[] { width, height, depth }, type );
-
-		if ( img == null )
-		{
-			r.close();
-			throw new RuntimeException( "Could not instantiate " + factory.getClass().getSimpleName() + " for '" + path + "', most likely out of memory." );
-		}
-		else
-			ReportingUtils.logMessage( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + width + "x" + height + "x" + depth + " ch=" + c + " tp=" + t + " type=" + pixelTypeString + " image=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
-
-		final byte[] b = new byte[width * height * bytesPerPixel];
-
-		final int planeX = 0;
-		final int planeY = 1;
-
-		for ( int z = 0; z < depth; ++z )
-		{
-			IJ.showProgress( ( double ) z / ( double ) depth );
-
-			final Cursor< T > cursor = Views.iterable( Views.hyperSlice( img, 2, z ) ).localizingCursor();
-
-			r.openBytes( r.getIndex( z, c, t ), b );
-
-			if ( pixelType == FormatTools.UINT8 )
-			{
-				while( cursor.hasNext() )
-				{
-					cursor.fwd();
-					cursor.get().setReal( b[ cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ] & 0xff );
-				}
-			}
-			else if ( pixelType == FormatTools.UINT16 )
-			{
-				while( cursor.hasNext() )
-				{
-					cursor.fwd();
-					cursor.get().setReal( getShortValueInt( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
-				}
-			}
-			else if ( pixelType == FormatTools.INT16 )
-			{
-				while( cursor.hasNext() )
-				{
-					cursor.fwd();
-					cursor.get().setReal( getShortValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
-				}
-			}
-			else if ( pixelType == FormatTools.UINT32 )
-			{
-				//TODO: Untested
-				while( cursor.hasNext() )
-				{
-					cursor.fwd();
-					cursor.get().setReal( getIntValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
-				}
-			}
-			else if ( pixelType == FormatTools.FLOAT )
-			{
-				while( cursor.hasNext() )
-				{
-					cursor.fwd();
-					cursor.get().setReal( getFloatValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
-				}
-			}
-		}
-
-		r.close();
-
-		IJ.showProgress( 1 );
-
-		return img;
-	}
-
-	protected static final float getFloatValue( final byte[] b, final int i, final boolean isLittleEndian )
-	{
-		if ( isLittleEndian )
-			return Float.intBitsToFloat( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
-		else
-			return Float.intBitsToFloat( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
-	}
-
-	protected static final int getIntValue( final byte[] b, final int i, final boolean isLittleEndian )
-	{
-		if ( isLittleEndian )
-			return ( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
-		else
-			return ( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
-	}
-
-	protected static final short getShortValue( final byte[] b, final int i, final boolean isLittleEndian )
-	{
-		return (short)getShortValueInt( b, i, isLittleEndian );
-	}
-
-	protected static final int getShortValueInt( final byte[] b, final int i, final boolean isLittleEndian )
-	{
-		if ( isLittleEndian )
-			return ((((b[i+1] & 0xff) << 8)) + (b[i] & 0xff));
-		else
-			return ((((b[i] & 0xff) << 8)) + (b[i+1] & 0xff));
-	}
-
-	protected static Angle getAngle( final BasicViewDescription< ? > vd )
-	{
-		final BasicViewSetup vs = vd.getViewSetup();
-		final Angle angle = vs.getAttribute( Angle.class );
-
-		if ( angle == null )
-			throw new RuntimeException( "This XML does not have the 'Angle' attribute for their ViewSetup. Cannot continue." );
-
-		return angle;
-	}
-
-	protected static Channel getChannel( final BasicViewDescription< ? > vd )
-	{
-		final BasicViewSetup vs = vd.getViewSetup();
-		final Channel channel = vs.getAttribute( Channel.class );
-
-		if ( channel == null )
-			throw new RuntimeException( "This XML does not have the 'Channel' attribute for their ViewSetup. Cannot continue." );
-
-		return channel;
-	}
-
-	@Override public UnsignedShortType getImageType()
-	{
-		return new UnsignedShortType();
+		legacyOMETiffImageLoader.setSequenceDescription( sequenceDescriptionMinimal );
 	}
 }

--- a/src/main/java/spim/io/imgloader/OMETiffImageLoader.java
+++ b/src/main/java/spim/io/imgloader/OMETiffImageLoader.java
@@ -1,0 +1,309 @@
+package spim.io.imgloader;
+
+import bdv.spimdata.SequenceDescriptionMinimal;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.io.Opener;
+import ij.process.ImageProcessor;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.ChannelSeparator;
+import loci.formats.FormatTools;
+import loci.formats.IFormatReader;
+import loci.formats.meta.IMetadata;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.services.OMEXMLService;
+import mpicbg.spim.data.generic.sequence.BasicImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicViewDescription;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.sequence.Angle;
+import mpicbg.spim.data.sequence.Channel;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.ViewId;
+import mpicbg.spim.data.sequence.ViewSetup;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.view.Views;
+import org.micromanager.utils.ReportingUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+
+/**
+ * Created by moon on 10/9/15.
+ */
+public class OMETiffImageLoader implements BasicImgLoader< UnsignedShortType >
+{
+	private final File file;
+
+	private HashMap< Integer, BasicViewSetup > setups;
+
+	private SequenceDescriptionMinimal sequenceDescriptionMinimal;
+
+	public OMETiffImageLoader( final File file )
+	{
+		this.file = file;
+	}
+
+	public void setSetups( HashMap< Integer, BasicViewSetup > setups )
+	{
+		this.setups = setups;
+	}
+
+	public void setSequenceDescription( SequenceDescriptionMinimal sequenceDescriptionMinimal )
+	{
+		this.sequenceDescriptionMinimal = sequenceDescriptionMinimal;
+	}
+
+	@Override public RandomAccessibleInterval< UnsignedShortType > getImage( ViewId view )
+	{
+		Img< UnsignedShortType > img = null;
+		try
+		{
+			img = openLOCI( file, new UnsignedShortType(), view );
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace();
+		}
+		return img;
+	}
+
+	public static boolean createOMEXMLMetadata( final IFormatReader r )
+	{
+		try
+		{
+			final ServiceFactory serviceFactory = new ServiceFactory();
+			final OMEXMLService service = serviceFactory.getInstance( OMEXMLService.class );
+			final IMetadata omexmlMeta = service.createOMEXMLMetadata();
+			r.setMetadataStore(omexmlMeta);
+		}
+		catch (final ServiceException e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+		catch (final DependencyException e)
+		{
+			e.printStackTrace();
+			return false;
+		}
+
+		return true;
+	}
+
+
+	protected < T extends RealType< T > & NativeType< T > > Img< T > openLOCI( final File path, final T type, final ViewId view ) throws Exception
+	{
+		BasicViewDescription< ? > viewDescription = sequenceDescriptionMinimal.getViewDescriptions().get( view );
+
+		final IFormatReader r = new ChannelSeparator();
+
+		if ( !createOMEXMLMetadata( r ) )
+		{
+			try
+			{
+				r.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		final String id = path.getAbsolutePath();
+
+		r.setId( id );
+		final Angle angle = getAngle( viewDescription );
+		r.setSeries( angle.getId() );
+
+		final boolean isLittleEndian = r.isLittleEndian();
+		final int width = r.getSizeX();
+		final int height = r.getSizeY();
+		final int depth = r.getSizeZ();
+		final int timepoints = r.getSizeT();
+		final int channels = r.getSizeC();
+		final int pixelType = r.getPixelType();
+		final int bytesPerPixel = FormatTools.getBytesPerPixel( pixelType );
+		final String pixelTypeString = FormatTools.getPixelTypeString( pixelType );
+
+		final TimePoint timePoint = viewDescription.getTimePoint();
+		int t = timePoint.getId();
+
+//		final Channel channel = getChannel( viewDescription );
+//		int c = channel.getId();
+		int c = 0;
+
+		final MetadataRetrieve retrieve = (MetadataRetrieve)r.getMetadataStore();
+
+		double calX, calY, calZ;
+
+		try
+		{
+			float cal = retrieve.getPixelsPhysicalSizeX( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calX = cal;
+
+			cal = retrieve.getPixelsPhysicalSizeY( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calY = cal;
+
+			cal = retrieve.getPixelsPhysicalSizeZ( 0 ).value().floatValue();
+			if ( cal == 0 )
+			{
+				cal = 1;
+			}
+			calZ = cal;
+		}
+		catch ( Exception e )
+		{
+			calX = calY = calZ = 1;
+		}
+
+		final Img< T > img;
+
+		ArrayImgFactory factory = new ArrayImgFactory< UnsignedShortType >();
+		img = factory.create( new long[] { width, height, depth }, type );
+
+		if ( img == null )
+		{
+			r.close();
+			throw new RuntimeException( "Could not instantiate " + factory.getClass().getSimpleName() + " for '" + path + "', most likely out of memory." );
+		}
+		else
+			ReportingUtils.logMessage( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + width + "x" + height + "x" + depth + " ch=" + c + " tp=" + t + " type=" + pixelTypeString + " image=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
+
+		final byte[] b = new byte[width * height * bytesPerPixel];
+
+		final int planeX = 0;
+		final int planeY = 1;
+
+		for ( int z = 0; z < depth; ++z )
+		{
+			IJ.showProgress( ( double ) z / ( double ) depth );
+
+			final Cursor< T > cursor = Views.iterable( Views.hyperSlice( img, 2, z ) ).localizingCursor();
+
+			r.openBytes( r.getIndex( z, c, t ), b );
+
+			if ( pixelType == FormatTools.UINT8 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( b[ cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ] & 0xff );
+				}
+			}
+			else if ( pixelType == FormatTools.UINT16 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getShortValueInt( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.INT16 )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getShortValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width ) * 2, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.UINT32 )
+			{
+				//TODO: Untested
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getIntValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
+				}
+			}
+			else if ( pixelType == FormatTools.FLOAT )
+			{
+				while( cursor.hasNext() )
+				{
+					cursor.fwd();
+					cursor.get().setReal( getFloatValue( b, ( cursor.getIntPosition( planeX )+ cursor.getIntPosition( planeY )*width )*4, isLittleEndian ) );
+				}
+			}
+		}
+
+		r.close();
+
+		IJ.showProgress( 1 );
+
+		return img;
+	}
+
+	protected static final float getFloatValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return Float.intBitsToFloat( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
+		else
+			return Float.intBitsToFloat( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
+	}
+
+	protected static final int getIntValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return ( ((b[i+3] & 0xff) << 24)  + ((b[i+2] & 0xff) << 16)  +  ((b[i+1] & 0xff) << 8)  + (b[i] & 0xff) );
+		else
+			return ( ((b[i] & 0xff) << 24)  + ((b[i+1] & 0xff) << 16)  +  ((b[i+2] & 0xff) << 8)  + (b[i+3] & 0xff) );
+	}
+
+	protected static final short getShortValue( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		return (short)getShortValueInt( b, i, isLittleEndian );
+	}
+
+	protected static final int getShortValueInt( final byte[] b, final int i, final boolean isLittleEndian )
+	{
+		if ( isLittleEndian )
+			return ((((b[i+1] & 0xff) << 8)) + (b[i] & 0xff));
+		else
+			return ((((b[i] & 0xff) << 8)) + (b[i+1] & 0xff));
+	}
+
+	protected static Angle getAngle( final BasicViewDescription< ? > vd )
+	{
+		final BasicViewSetup vs = vd.getViewSetup();
+		final Angle angle = vs.getAttribute( Angle.class );
+
+		if ( angle == null )
+			throw new RuntimeException( "This XML does not have the 'Angle' attribute for their ViewSetup. Cannot continue." );
+
+		return angle;
+	}
+
+	protected static Channel getChannel( final BasicViewDescription< ? > vd )
+	{
+		final BasicViewSetup vs = vd.getViewSetup();
+		final Channel channel = vs.getAttribute( Channel.class );
+
+		if ( channel == null )
+			throw new RuntimeException( "This XML does not have the 'Channel' attribute for their ViewSetup. Cannot continue." );
+
+		return channel;
+	}
+
+	@Override public UnsignedShortType getImageType()
+	{
+		return new UnsignedShortType();
+	}
+}

--- a/src/main/java/spim/util/DelayChecker.java
+++ b/src/main/java/spim/util/DelayChecker.java
@@ -1,0 +1,50 @@
+package spim.util;
+
+import ij.IJ;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Delay checker class
+ * When the specific process delays more than 5 seconds, it will informed to IJ.log
+ */
+public class DelayChecker extends TimerTask
+{
+	final long delay;
+	long previousTime;
+	final Timer timer;
+
+	public DelayChecker( long millis )
+	{
+		previousTime = System.currentTimeMillis();
+		delay = millis;
+		timer = new Timer( true );
+		timer.scheduleAtFixedRate(this, 0, delay);
+	}
+
+	public void reset()
+	{
+		previousTime = System.currentTimeMillis();
+	}
+
+	public boolean isDelayed()
+	{
+		final long currentTime = System.currentTimeMillis();
+
+		return previousTime + delay < currentTime;
+	}
+
+	public void stop()
+	{
+		timer.cancel();
+	}
+
+	@Override
+	public void run() {
+		if ( isDelayed() )
+		{
+			IJ.log( "[WARNING] The current process takes longer than " + delay / 1000 + " secs delay." );
+		}
+	}
+}

--- a/src/main/java/spim/util/DelayChecker.java
+++ b/src/main/java/spim/util/DelayChecker.java
@@ -14,9 +14,19 @@ public class DelayChecker extends TimerTask
 	final long delay;
 	long previousTime;
 	final Timer timer;
+	private Thread thread;
 
 	public DelayChecker( long millis )
 	{
+		previousTime = System.currentTimeMillis();
+		delay = millis;
+		timer = new Timer( true );
+		timer.scheduleAtFixedRate(this, 0, delay);
+	}
+
+	public DelayChecker( Thread thread, long millis )
+	{
+		this.thread = thread;
 		previousTime = System.currentTimeMillis();
 		delay = millis;
 		timer = new Timer( true );
@@ -45,6 +55,12 @@ public class DelayChecker extends TimerTask
 		if ( isDelayed() )
 		{
 			IJ.log( "[WARNING] The current process takes longer than " + delay / 1000 + " secs delay." );
+			if(thread != null)
+			{
+				thread.interrupt();
+				IJ.log( "[WARNING] The acquisition is interrupted due to taking longer than " + delay / 1000 + " secs delay." );
+				thread = null;
+			}
 		}
 	}
 }

--- a/src/test/java/AntiDriftTest.java
+++ b/src/test/java/AntiDriftTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import spim.algorithm.AntiDrift;
 import spim.controller.AntiDriftController;
 import spim.algorithm.DefaultAntiDrift;
+import utils.ImageGenerator;
 
 import java.awt.*;
 import java.io.File;
@@ -42,38 +43,7 @@ public class AntiDriftTest
 		return result;
 	}
 
-	/**
-	 * Generates a Gaussian 3D blob.
-	 *
-	 * @param width the width of the output image
-	 * @param height the height of the output image
-	 * @param depth the depth of the output image
-	 * @param centerX the x-coordinate of the center of the blob
-	 * @param centerY the y-coordinate of the center of the blob
-	 * @param centerZ the z-coordinate of the center of the blob
-	 * @param sigmaX the fuzzy radius in x direction
-	 * @param sigmaY the fuzzy radius in y direction
-	 * @param sigmaZ the fuzzy radius in z direction
-	 * @return the image with the blob
-	 */
-	private static ImagePlus generateBlob(final int width, final int height, final int depth,
-			final float centerX, final float centerY, final float centerZ,
-			final float sigmaX, final float sigmaY, final float sigmaZ) {
 
-		final float[] gaussX = gauss(width, centerX, sigmaX);
-		final float[] gaussY = gauss(height, centerY, sigmaY);
-		final float[] gaussZ = gauss(depth, centerZ, sigmaZ);
-
-		final ImageStack stack = new ImageStack(width, height);
-		for (int k = 0; k < depth; k++) {
-			final float[] pixels = new float[width * height];
-			for (int j = 0; j < height; j++)
-				for (int i = 0; i < width; i++)
-					pixels[i + width * j] = gaussX[i] * gaussY[j] * gaussZ[k];
-			stack.addSlice(null, new FloatProcessor(width, height, pixels, null));
-		}
-		return new ImagePlus("Blob", stack);
-	}
 
 	/**
 	 * setup the images
@@ -84,9 +54,9 @@ public class AntiDriftTest
 		// impFirst = generateBlob(128, 128, 128, 64, 32, 48, 50 / 8.0f , 30 / 4.0f, 40 / 4.0f);
 		// impSecond = generateBlob(128, 128, 128, 64 + 16, 32 + 24, 48 + 32, 40 /8.0f, 20 / 4.0f, 30 / 4.0f);
 		// The below parameters are simplified version with above ratio
-		impFirst = generateBlob(128, 128, 128, 64, 32, 48, 12.5f , 7.5f, 10.0f);
-		impSecond = generateBlob(128, 128, 128, 64 + 16, 32 + 24, 48 + 32, 5.0f, 5.0f, 7.5f);
-		impThird = generateBlob(128, 128, 128, 64 + 8, 32 + 32, 48 + 24, 4.0f, 4.0f, 6.5f);
+		impFirst = ImageGenerator.generateFloatBlob(128, 128, 128, 64, 32, 48, 12.5f , 7.5f, 10.0f);
+		impSecond = ImageGenerator.generateFloatBlob(128, 128, 128, 64 + 16, 32 + 24, 48 + 32, 5.0f, 5.0f, 7.5f);
+		impThird = ImageGenerator.generateFloatBlob(128, 128, 128, 64 + 8, 32 + 32, 48 + 24, 4.0f, 4.0f, 6.5f);
 	}
 
 	/**

--- a/src/test/java/AntiDriftTest.java
+++ b/src/test/java/AntiDriftTest.java
@@ -21,6 +21,7 @@ public class AntiDriftTest
 {
 	private ImagePlus impFirst;
 	private ImagePlus impSecond;
+	private ImagePlus impThird;
 
 
 	/**
@@ -84,6 +85,7 @@ public class AntiDriftTest
 		// The below parameters are simplified version with above ratio
 		impFirst = generateBlob(128, 128, 128, 64, 32, 48, 12.5f , 7.5f, 10.0f);
 		impSecond = generateBlob(128, 128, 128, 64 + 16, 32 + 24, 48 + 32, 5.0f, 5.0f, 7.5f);
+		impThird = generateBlob(128, 128, 128, 64 + 8, 32 + 32, 48 + 24, 4.0f, 4.0f, 6.5f);
 	}
 
 	/**
@@ -147,6 +149,22 @@ public class AntiDriftTest
 		for(int k = 1; k <= stackSecond.getSize(); k++)
 		{
 			ct.addXYSlice( stackSecond.getProcessor( k ) );
+		}
+		ct.finishStack();
+
+		try
+		{
+			Thread.sleep( 10000 );
+		} catch (InterruptedException e)
+		{
+			e.printStackTrace();
+		}
+
+		ct.startNewStack();
+		final ImageStack stackThird = impThird.getImageStack();
+		for(int k = 1; k <= stackThird.getSize(); k++)
+		{
+			ct.addXYSlice( stackThird.getProcessor( k ) );
 		}
 		ct.finishStack();
 	}

--- a/src/test/java/AntiDriftTest.java
+++ b/src/test/java/AntiDriftTest.java
@@ -110,10 +110,10 @@ public class AntiDriftTest
 		{
 			proj.addXYSlice( stackSecond.getProcessor( k ) );
 		}
-		proj.finishStack( );
 
+		final Vector3D correction = proj.finishStack( );
 		final double DELTA = 1e-5;
-		final Vector3D correction = proj.getLastCorrection();
+
 		Assert.assertEquals(16, correction.getX(), DELTA);
 		Assert.assertEquals(24, correction.getY(), DELTA);
 		Assert.assertEquals(32, correction.getZ(), DELTA);

--- a/src/test/java/AntiDriftTest.java
+++ b/src/test/java/AntiDriftTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
+import spim.algorithm.AntiDrift;
 import spim.controller.AntiDriftController;
 import spim.algorithm.DefaultAntiDrift;
 
@@ -119,6 +120,14 @@ public class AntiDriftTest
 	public void testAntiDriftController()
 	{
 		final AntiDriftController ct = new AntiDriftController( new File("/Users/moon/temp/"), 2, 3, 4, 0, 1, 0);
+
+		ct.setCallback(new AntiDrift.Callback() {
+			public void applyOffset(Vector3D offs) {
+				offs = new Vector3D(offs.getX()*-1, offs.getY()*-1, -offs.getZ());
+				System.out.println(String.format("Offset: %s", offs.toString()));
+			}
+		});
+
 		ct.startNewStack();
 
 		final ImageStack stackFirst = impFirst.getImageStack();

--- a/src/test/java/AntiDriftTest.java
+++ b/src/test/java/AntiDriftTest.java
@@ -9,7 +9,10 @@ import spim.algorithm.AntiDrift;
 import spim.controller.AntiDriftController;
 import spim.algorithm.DefaultAntiDrift;
 
+import java.awt.*;
 import java.io.File;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * The type Anti drift handler test.
@@ -119,6 +122,8 @@ public class AntiDriftTest
 	 */
 	public void testAntiDriftController()
 	{
+		assumeTrue(!GraphicsEnvironment.isHeadless());
+
 		final AntiDriftController ct = new AntiDriftController( new File("/Users/moon/temp/"), 2, 3, 4, 0, 1, 0);
 
 		ct.setCallback(new AntiDrift.Callback() {

--- a/src/test/java/DelayCheckerTest.java
+++ b/src/test/java/DelayCheckerTest.java
@@ -1,0 +1,30 @@
+import org.junit.Test;
+import org.junit.Assert;
+import spim.util.DelayChecker;
+
+/**
+ * Unit test class for delay checker
+ */
+public class DelayCheckerTest
+{
+	@Test
+	public void moreThan5seconds()
+	{
+		DelayChecker checker = new DelayChecker( 5000 );
+
+		checker.reset();
+
+		try
+		{
+			Thread.sleep( 11000 );
+		}
+		catch ( InterruptedException e )
+		{
+			e.printStackTrace();
+		}
+
+		checker.stop();
+
+		Assert.assertTrue( checker.isDelayed() );
+	}
+}

--- a/src/test/java/DelayCheckerTest.java
+++ b/src/test/java/DelayCheckerTest.java
@@ -27,4 +27,43 @@ public class DelayCheckerTest
 
 		Assert.assertTrue( checker.isDelayed() );
 	}
+
+	@Test
+	public void moreThan5secondsWithThread()
+	{
+		Thread thread = new Thread(){
+			@Override
+			public void run()
+			{
+				DelayChecker checker = new DelayChecker( Thread.currentThread(), 5000 );
+
+				checker.reset();
+
+				try
+				{
+					Thread.sleep( 11000 );
+				}
+				catch ( InterruptedException e )
+				{
+					e.printStackTrace();
+				}
+
+				checker.stop();
+			}
+		};
+
+		thread.start();
+
+		try
+		{
+			thread.join();
+		}
+		catch ( InterruptedException e )
+		{
+			e.printStackTrace();
+		}
+
+		//Assert.assertTrue( checker.isDelayed() );
+	}
+
 }

--- a/src/test/java/OmeTiffTestCreator.java
+++ b/src/test/java/OmeTiffTestCreator.java
@@ -1,0 +1,265 @@
+import ij.ImagePlus;
+import ij.process.ImageProcessor;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatTools;
+import loci.formats.IFormatWriter;
+import loci.formats.ImageWriter;
+import loci.formats.MetadataTools;
+import loci.formats.meta.IMetadata;
+import loci.formats.out.OMETiffWriter;
+import loci.formats.services.OMEXMLService;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
+import utils.ImageGenerator;
+
+import java.io.File;
+
+/**
+ * Create OmeTiff with multi-angle, multi-timeseries, multi-stack, multi-channel
+ *
+ * @author HongKee Moon
+ */
+public class OmeTiffTestCreator
+{
+	private File outputDirectory = new File( "/Users/moon/Desktop/ome" );
+	private IMetadata meta;
+	private IFormatWriter writer;
+	private int imageCounter, sliceCounter;
+
+	private int angleSize;
+	private int channelSize;
+	private int tSize, zSize, xSize, ySize;
+
+	private static String makeFilename( int angleIndex, int timepoint )
+	{
+		return String.format( "Test_TL%02d_Angle%01d.ome.tiff", timepoint, angleIndex );
+	}
+
+	public OmeTiffTestCreator()
+	{
+		imageCounter = -1;
+		sliceCounter = 0;
+
+		angleSize = 4;
+		channelSize = 2;
+
+		tSize = 9;
+		zSize = 128;
+		xSize = 128;
+		ySize = 128;
+
+		try
+		{
+			meta = new ServiceFactory().getInstance( OMEXMLService.class ).createOMEXMLMetadata();
+
+			meta.createRoot();
+
+			meta.setDatasetID( MetadataTools.createLSID( "Dataset", 0 ), 0 );
+
+			for ( int image = 0; image < angleSize; ++image )
+			{
+				meta.setImageID( MetadataTools.createLSID( "Image", image ), image );
+
+				meta.setPixelsID( MetadataTools.createLSID( "Pixels", image ), image );
+				meta.setPixelsDimensionOrder( DimensionOrder.XYCZT, image );
+				meta.setPixelsBinDataBigEndian( Boolean.FALSE, image, 0 );
+				meta.setPixelsType( PixelType.UINT8, image );
+
+				for ( int c = 0; c < channelSize; ++c )
+				{
+					meta.setChannelID( MetadataTools.createLSID( "Channel", image ), image, c );
+					meta.setChannelSamplesPerPixel( new PositiveInteger(1), image, c );
+				}
+
+				for ( int t = 0; t < tSize; ++t )
+				{
+					String fileName = makeFilename( image % angleSize, t );
+					for ( int z = 0; z < zSize; ++z )
+					{
+
+						int td = zSize * t + z ;
+						meta.setUUIDFileName( fileName, image, td );
+
+						meta.setTiffDataPlaneCount( new NonNegativeInteger( channelSize ), image, td );
+						meta.setTiffDataFirstT( new NonNegativeInteger( t ), image, td );
+						meta.setTiffDataFirstZ( new NonNegativeInteger( z ), image, td );
+						meta.setTiffDataFirstC( new NonNegativeInteger( 0 ), image, td );
+					}
+				}
+
+				meta.setPixelsSizeX( new PositiveInteger( xSize ), image );
+				meta.setPixelsSizeY( new PositiveInteger( ySize ), image );
+				meta.setPixelsSizeC( new PositiveInteger( channelSize ), image );
+				meta.setPixelsSizeZ( new PositiveInteger( zSize ), image );
+				meta.setPixelsSizeT( new PositiveInteger( tSize ), image );
+
+				meta.setPixelsPhysicalSizeX( FormatTools.getPhysicalSizeX( 0.035 ), image );
+				meta.setPixelsPhysicalSizeY( FormatTools.getPhysicalSizeX( 0.035 ), image );
+				meta.setPixelsPhysicalSizeZ( FormatTools.getPhysicalSizeX( Math.max( 0.01, 1.0D ) ), image );
+				meta.setPixelsTimeIncrement( new Time( new Double( 1 ), UNITS.S ), image );
+			}
+
+			writer = new ImageWriter().getWriter( makeFilename( 0, 0 ) );
+			if ( writer instanceof OMETiffWriter )
+			{
+				ij.IJ.log( "calling setBigTiff(true)" );
+				( ( OMETiffWriter ) writer ).setBigTiff( true );
+			}
+
+			writer.setWriteSequentially( true );
+			writer.setMetadataRetrieve( meta );
+			writer.setInterleaved( false );
+			writer.setValidBitsPerPixel( 8 );
+			writer.setCompression( "Uncompressed" );
+		}
+		catch ( Throwable t )
+		{
+			t.printStackTrace();
+			throw new IllegalArgumentException( t );
+		}
+	}
+
+	private void openWriter( int angleIndex, int timepoint) throws Exception
+	{
+		writer.changeOutputFile( new File( outputDirectory, meta.getUUIDFileName( angleIndex, zSize * timepoint ) ).getAbsolutePath() );
+		writer.setSeries( angleIndex );
+		meta.setUUID( meta.getUUIDValue( angleIndex, zSize * timepoint ) );
+
+		sliceCounter = 0;
+	}
+
+	public void beginStack() throws Exception
+	{
+		if ( ++imageCounter < angleSize * zSize )
+			openWriter( imageCounter % angleSize, imageCounter / angleSize );
+	}
+
+	private int doubleAnnotations = 0;
+
+	private int storeDouble( int image, int plane, int n, String name, double val )
+	{
+		String key = String.format( "%d/%d/%d: %s", image, plane, n, name );
+
+		meta.setDoubleAnnotationID( key, doubleAnnotations );
+		meta.setDoubleAnnotationValue( val, doubleAnnotations );
+		meta.setPlaneAnnotationRef( key, image, plane, n );
+
+		return doubleAnnotations++;
+	}
+
+	// ImageProcessor should have multiple channels
+	public void processSlice( ImageProcessor ip, int channel, double X, double Y, double Z, double theta, double deltaT )
+			throws Exception
+	{
+		byte[] data = ( byte[] ) ip.getPixels();
+
+		int image = imageCounter % angleSize;
+		int timePoint = imageCounter / angleSize;
+		int plane = timePoint * zSize + sliceCounter;
+
+		meta.setPlanePositionX( new Length( X, UNITS.REFERENCEFRAME ), image, plane );
+		meta.setPlanePositionY( new Length( Y, UNITS.REFERENCEFRAME ), image, plane );
+		meta.setPlanePositionZ( new Length( Z, UNITS.REFERENCEFRAME ), image, plane );
+		meta.setPlaneTheC( new NonNegativeInteger( channel ), image, plane );
+		meta.setPlaneTheZ( new NonNegativeInteger( sliceCounter ), image, plane );
+		meta.setPlaneTheT( new NonNegativeInteger( timePoint ), image, plane );
+		meta.setPlaneDeltaT( new Time( deltaT, UNITS.S ), image, plane );
+
+		storeDouble( image, plane, 0, "Theta", theta );
+
+		try
+		{
+			writer.saveBytes( plane, data );
+		}
+		catch ( java.io.IOException ioe )
+		{
+			finalizeStack();
+			if ( writer != null )
+				writer.close();
+			throw new Exception( "Error writing OME-TIFF.", ioe );
+		}
+
+		++sliceCounter;
+	}
+
+	public void finalizeStack() throws Exception
+	{
+	}
+
+	public void finalizeAcquisition() throws Exception
+	{
+		if ( writer != null )
+			writer.close();
+
+		imageCounter = 0;
+
+		writer = null;
+	}
+
+	public void produceOmeTiff() throws Exception
+	{
+		int width = xSize, height = ySize, depth = zSize, time = tSize;
+
+		for (int t=1; t <= time; t++)
+		{
+			// angle 0
+			ImagePlus firstChannel0 = ImageGenerator.generateByteBlob( width, height, depth, 32 + 3 * t, 32 + 3 * t, 64, 12.5f, 12.5f, 10.0f );
+			ImagePlus secondChannel0 = ImageGenerator.generateByteBlob(width, height, depth, 32 + 3*t, 32 + 3*t, 64, 5.0f, 5.0f, 7.5f);
+			beginStack();
+			for (int z=1; z <= depth; z++) {
+				processSlice( firstChannel0.getStack().getProcessor( z ), 0, 0, 0, z - 1, 0, t - 1 );
+				processSlice( secondChannel0.getStack().getProcessor( z ), 1, 0, 0, z - 1, 0, t - 1);
+			}
+			finalizeStack();
+
+			// angle 1
+			ImagePlus firstChannel1 = ImageGenerator.generateByteBlob(width, height, depth, 96 - 3*t, 96 - 3*t, 64, 12.5f , 12.5f, 10.0f);
+			ImagePlus secondChannel1 = ImageGenerator.generateByteBlob(width, height, depth, 96 - 3*t, 96 - 3*t, 64, 5.0f, 5.0f, 7.5f);
+			beginStack();
+			for (int z=1; z <= depth; z++) {
+				processSlice( firstChannel1.getStack().getProcessor( z ), 0, 1, 0, z - 1, 1, t - 1 );
+				processSlice( secondChannel1.getStack().getProcessor( z ), 1, 1, 0, z - 1, 1, t - 1);
+			}
+			finalizeStack();
+
+			// angle 2
+			ImagePlus firstChannel2 = ImageGenerator.generateByteBlob(width, height, depth, 96 - 3*t, 32 + 3*t, 64, 12.5f , 12.5f, 10.0f);
+			ImagePlus secondChannel2 = ImageGenerator.generateByteBlob(width, height, depth, 96 - 3*t, 32 + 3*t, 64, 5.0f, 5.0f, 7.5f);
+			beginStack();
+			for (int z=1; z <= depth; z++) {
+				processSlice( firstChannel2.getStack().getProcessor( z ), 0, 0, 1, z - 1, 2, t - 1 );
+				processSlice( secondChannel2.getStack().getProcessor( z ), 1, 0, 1, z - 1, 2, t - 1);
+			}
+
+			// angle 3
+			ImagePlus firstChannel3 = ImageGenerator.generateByteBlob(width, height, depth, 32 + 3*t, 96 - 3*t, 64, 12.5f , 12.5f, 10.0f);
+			ImagePlus secondChannel3 = ImageGenerator.generateByteBlob(width, height, depth, 32 + 3*t, 96 - 3*t, 64, 5.0f, 5.0f, 7.5f);
+			beginStack();
+			for (int z=1; z <= depth; z++) {
+				processSlice( firstChannel3.getStack().getProcessor( z ), 0, 0, 1, z - 1, 2, t - 1 );
+				processSlice( secondChannel3.getStack().getProcessor( z ), 1, 0, 1, z - 1, 2, t - 1);
+			}
+			finalizeStack();
+		}
+
+		finalizeAcquisition();
+	}
+
+	public static void main( String[] args )
+	{
+		OmeTiffTestCreator creator = new OmeTiffTestCreator();
+		try
+		{
+			creator.produceOmeTiff();
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/test/java/utils/ImageGenerator.java
+++ b/src/test/java/utils/ImageGenerator.java
@@ -1,0 +1,98 @@
+package utils;
+
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
+
+/**
+ * Generates test images
+ * @author Johannes Schindelin
+ * @author HongKee Moon
+ */
+public class ImageGenerator
+{
+	/**
+	 * Calculates the Gauss function (AKA kernel) of the given parameters.
+	 *
+	 * @param size the size of the kernel
+	 * @param center the center of the Gaussian function
+	 * @param sigma the standard deviation of the Gaussian function
+	 * @return the kernel
+	 */
+	private static float[] gauss(final int size, final float center, final float sigma) {
+		final float[] result = new float[size];
+		for (int i = 0; i < size; i++) {
+			final float x = (i - center) / sigma;
+			result[i] = (float) Math.exp(-x * x / 2);
+		}
+		return result;
+	}
+
+	/**
+	 * Generates a Gaussian 3D blob.
+	 *
+	 * @param width the width of the output image
+	 * @param height the height of the output image
+	 * @param depth the depth of the output image
+	 * @param centerX the x-coordinate of the center of the blob
+	 * @param centerY the y-coordinate of the center of the blob
+	 * @param centerZ the z-coordinate of the center of the blob
+	 * @param sigmaX the fuzzy radius in x direction
+	 * @param sigmaY the fuzzy radius in y direction
+	 * @param sigmaZ the fuzzy radius in z direction
+	 * @return the image with the blob
+	 */
+	public static ImagePlus generateFloatBlob( final int width, final int height, final int depth,
+			final float centerX, final float centerY, final float centerZ,
+			final float sigmaX, final float sigmaY, final float sigmaZ ) {
+
+		final float[] gaussX = gauss(width, centerX, sigmaX);
+		final float[] gaussY = gauss(height, centerY, sigmaY);
+		final float[] gaussZ = gauss(depth, centerZ, sigmaZ);
+
+		final ImageStack stack = new ImageStack(width, height);
+		for (int k = 0; k < depth; k++) {
+			final float[] pixels = new float[width * height];
+			for (int j = 0; j < height; j++)
+				for (int i = 0; i < width; i++)
+					pixels[i + width * j] = gaussX[i] * gaussY[j] * gaussZ[k];
+			stack.addSlice(null, new FloatProcessor(width, height, pixels, null));
+		}
+		return new ImagePlus("Blob", stack);
+	}
+
+	/**
+	 * Generates a Gaussian 3D blob.
+	 *
+	 * @param width the width of the output image
+	 * @param height the height of the output image
+	 * @param depth the depth of the output image
+	 * @param centerX the x-coordinate of the center of the blob
+	 * @param centerY the y-coordinate of the center of the blob
+	 * @param centerZ the z-coordinate of the center of the blob
+	 * @param sigmaX the fuzzy radius in x direction
+	 * @param sigmaY the fuzzy radius in y direction
+	 * @param sigmaZ the fuzzy radius in z direction
+	 * @return the image with the blob
+	 */
+	public static ImagePlus generateByteBlob( final int width, final int height, final int depth,
+			final float centerX, final float centerY, final float centerZ,
+			final float sigmaX, final float sigmaY, final float sigmaZ ) {
+
+		final float[] gaussX = gauss(width, centerX, sigmaX);
+		final float[] gaussY = gauss(height, centerY, sigmaY);
+		final float[] gaussZ = gauss(depth, centerZ, sigmaZ);
+
+		final ImageStack stack = new ImageStack(width, height);
+		for (int k = 0; k < depth; k++) {
+			final byte[] pixels = new byte[width * height];
+			for (int j = 0; j < height; j++)
+				for (int i = 0; i < width; i++)
+					pixels[i + width * j] = (byte) ((gaussX[i] * gaussY[j] * gaussZ[k]) * 255);
+			stack.addSlice(null, new ByteProcessor(width, height, pixels, null));
+		}
+		return new ImagePlus("Blob", stack);
+	}
+
+}


### PR DESCRIPTION
@dscho This contains today's changes and additionally some bug patches which are reported by @Peter-Gabriel-Pitrone. 

1. Suddenly, Tiff saving did not work so that I included bio-formats 5.1.2.
1. DelayChecker is a Timer which checks it by given delay factor.
1. ```LiveWindowMouseAdapter.attach()``` might have non-CenterAndDragListener components. I changed the logics.
1. ```Point drag = new Point(me.getX() - dragStart.x, dragStart.y - me.getY());``` : Inverse the Y calculation.
