### PR TITLE
metadata of acquired images patch

### DIFF
--- a/src/main/java/spim/progacq/OMETIFFHandler.java
+++ b/src/main/java/spim/progacq/OMETIFFHandler.java
@@ -115,7 +115,7 @@ public class OMETIFFHandler implements AcqOutputHandler {
 	}
 
 	private static String makeFilename(int angleIndex, int timepoint) {
-		return String.format("spim_TL%02d_Angle%01d.ome.tiff", (timepoint + 1), angleIndex);
+		return String.format("spim_TL%02d_Angle%02d.ome.tiff", (timepoint + 1), angleIndex);
 	}
 
 	private void openWriter(int angleIndex, int timepoint) throws Exception {

--- a/src/main/java/spim/progacq/OMETIFFHandler.java
+++ b/src/main/java/spim/progacq/OMETIFFHandler.java
@@ -78,6 +78,7 @@ public class OMETIFFHandler implements AcqOutputHandler {
 					for(int z = 0; z < depth; ++z) {
 						int td = depth*t + z;
 
+						meta.setImageName(fileName, image);
 						meta.setUUIDFileName(fileName, image, td);
 //						meta.setUUIDValue("urn:uuid:" + (String)UUID.nameUUIDFromBytes(fileName.getBytes()).toString(), image, td);
 


### PR DESCRIPTION
after adding this line, different stacks (i.e. different angles or XY positions) have unique names when opened in Fiji using Bioformats. However, this is not very elegant - better ideas welcome