### PR TITLE
more flexible filenames

### DIFF
--- a/src/main/java/spim/io/OMETIFFHandler.java
+++ b/src/main/java/spim/io/OMETIFFHandler.java
@@ -55,8 +55,7 @@ public class OMETIFFHandler implements OutputHandler
 		outputDirectory = outDir;
 		this.acqRows = acqRows;
 		tiles = tileCount;
-		int angles = Math.floorDiv(stacks, tiles);
-		ReportingUtils.showMessage("angles="+angles);
+		int angles = (int) (stacks / tiles);
 		
 		try {
 			meta = new ServiceFactory().getInstance(OMEXMLService.class).createOMEXMLMetadata();
@@ -78,8 +77,10 @@ public class OMETIFFHandler implements OutputHandler
 				meta.setChannelID(MetadataTools.createLSID("Channel", 0), image, 0);
 				meta.setChannelSamplesPerPixel(new PositiveInteger(1), image, 0);
 
+				int positionIndex = (int) (image/angles);
+				
 				for (int t = 0; t < timesteps; ++t) {
-					String fileName = makeFilename(filenamePrefix, image % angles, t, Math.floorDiv(image, angles), (tiles>=1));
+					String fileName = makeFilename(filenamePrefix, image % angles, t, positionIndex, (tiles>1));
 					for(int z = 0; z < depth; ++z) {
 						int td = depth*t + z;
 

--- a/src/main/java/spim/io/OMETIFFHandler.java
+++ b/src/main/java/spim/io/OMETIFFHandler.java
@@ -34,13 +34,13 @@ public class OMETIFFHandler implements OutputHandler
 	private IFormatWriter writer;
 
 	private CMMCore core;
-	private int stacks, timesteps;
+	private int stacks, timesteps, tiles;
 	private Row[] acqRows;
 	private double deltat;
 	
-	public OMETIFFHandler(CMMCore iCore, File outDir, String xyDev,
+	public OMETIFFHandler(CMMCore iCore, File outDir, String filenamePrefix, String xyDev,
 			String cDev, String zDev, String tDev, Row[] acqRows,
-			int iTimeSteps, double iDeltaT) {
+			int iTimeSteps, double iDeltaT, int tileCount) {
 
 		if(outDir == null || !outDir.exists() || !outDir.isDirectory())
 			throw new IllegalArgumentException("Null path specified: " + outDir.toString());
@@ -54,7 +54,10 @@ public class OMETIFFHandler implements OutputHandler
 		deltat = iDeltaT;
 		outputDirectory = outDir;
 		this.acqRows = acqRows;
-
+		tiles = tileCount;
+		int angles = Math.floorDiv(stacks, tiles);
+		ReportingUtils.showMessage("angles="+angles);
+		
 		try {
 			meta = new ServiceFactory().getInstance(OMEXMLService.class).createOMEXMLMetadata();
 
@@ -76,7 +79,7 @@ public class OMETIFFHandler implements OutputHandler
 				meta.setChannelSamplesPerPixel(new PositiveInteger(1), image, 0);
 
 				for (int t = 0; t < timesteps; ++t) {
-					String fileName = makeFilename(image, t);
+					String fileName = makeFilename(filenamePrefix, image % angles, t, Math.floorDiv(image, angles), (tiles>=1));
 					for(int z = 0; z < depth; ++z) {
 						int td = depth*t + z;
 
@@ -102,7 +105,7 @@ public class OMETIFFHandler implements OutputHandler
 				meta.setPixelsTimeIncrement(new Time(new Double(deltat), UNITS.S), image);
 			}
 
-			writer = new ImageWriter().getWriter(makeFilename(0, 0));
+			writer = new ImageWriter().getWriter(makeFilename(filenamePrefix, 0, 0, 0, false));
 
 			writer.setWriteSequentially(true);
 			writer.setMetadataRetrieve(meta);
@@ -115,8 +118,13 @@ public class OMETIFFHandler implements OutputHandler
 		}
 	}
 
-	private static String makeFilename(int angleIndex, int timepoint) {
-		return String.format("spim_TL%02d_Angle%01d.ome.tiff", (timepoint + 1), angleIndex);
+	private static String makeFilename(String filenamePrefix, int angleIndex, int timepoint, int posIndex, boolean multiplePos) {
+		String posString = new String();
+		if (multiplePos)
+			posString=String.format("Pos%02d_", posIndex);
+		else
+			posString="";
+		return String.format(filenamePrefix+"TL%02d_"+posString+"Angle%01d.ome.tiff", (timepoint + 1), angleIndex);
 	}
 
 	private void openWriter(int angleIndex, int timepoint) throws Exception {


### PR DESCRIPTION
1. text field added for editable filename prefix, "spim_" kept as
default for backward compatibility
2. if X and Y ranges specified by SPIM Ranges tab, filename will contain
PosXX to distinguis different X/Y positions from Angles (currently both
X/Y and Angle changes result in changing only the Angle indes)