### PR TITLE
Use the SciJava fork of Java 3D 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -18,30 +18,30 @@
 
 	<properties>
 		<enforcer.skip>true</enforcer.skip>
-        <bio-formats.version>5.1.2</bio-formats.version>
+		<bio-formats.version>5.1.2</bio-formats.version>
 	</properties>
 
 	<dependencies>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-gpl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>ome-xml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ome</groupId>
-            <artifactId>formats-bsd</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-gpl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>ome-xml</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>formats-bsd</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>
@@ -103,60 +103,60 @@
 			<artifactId>j3d-core-utils</artifactId>
 			<scope>provided</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.beanshell</groupId>
-            <artifactId>bsh</artifactId>
-            <version>2.0b4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fifesoft</groupId>
-            <artifactId>rsyntaxtextarea</artifactId>
-            <version>2.5.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>clojure</artifactId>
-            <version>1.6.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.miglayout</groupId>
-            <artifactId>miglayout-swing</artifactId>
-            <version>4.2</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.beanshell</groupId>
+			<artifactId>bsh</artifactId>
+			<version>2.0b4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fifesoft</groupId>
+			<artifactId>rsyntaxtextarea</artifactId>
+			<version>2.5.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.clojure</groupId>
+			<artifactId>clojure</artifactId>
+			<version>1.6.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.miglayout</groupId>
+			<artifactId>miglayout-swing</artifactId>
+			<version>4.2</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- test-->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-math</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>sc.fiji</groupId>
-            <artifactId>spim_data</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>sc.fiji</groupId>
-            <artifactId>bigdataviewer-core</artifactId>
-            <version>2.1.0</version>
-        </dependency>
-    </dependencies>
+		<!-- test-->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>spim_data</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>bigdataviewer-core</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+	</dependencies>
 
 	<!-- NB: for project parent -->
 	<repositories>
@@ -164,9 +164,9 @@
 			<id>imagej.releases</id>
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
-        <repository>
-            <id>fiji.releases</id>
-            <url>http://dev.loci.wisc.edu/maven2/releases</url>
-        </repository>
+		<repository>
+			<id>fiji.releases</id>
+			<url>http://dev.loci.wisc.edu/maven2/releases</url>
+		</repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>16.2.0</version>
+		<version>18.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -18,6 +18,8 @@
 
 	<properties>
 		<enforcer.skip>true</enforcer.skip>
+		<scijava.jvm.version>1.7</scijava.jvm.version>
+		<ImageJ_3D_Viewer.version>4.0.1</ImageJ_3D_Viewer.version>
 		<bio-formats.version>5.1.2</bio-formats.version>
 	</properties>
 
@@ -96,19 +98,8 @@
 			<artifactId>imglib2-ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>java3d</groupId>
+			<groupId>org.scijava</groupId>
 			<artifactId>vecmath</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>java3d</groupId>
-			<artifactId>j3d-core</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>java3d</groupId>
-			<artifactId>j3d-core-utils</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.beanshell</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
 		<bio-formats.version>5.1.2</bio-formats.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>ome</groupId>
@@ -157,11 +164,4 @@
 			<version>2.1.0</version>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,15 +158,10 @@
 		</dependency>
 	</dependencies>
 
-	<!-- NB: for project parent -->
 	<repositories>
 		<repository>
-			<id>imagej.releases</id>
+			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>fiji.releases</id>
-			<url>http://dev.loci.wisc.edu/maven2/releases</url>
 		</repository>
 	</repositories>
 </project>

--- a/src/main/java/spim/gui/calibration/AutoWindow.java
+++ b/src/main/java/spim/gui/calibration/AutoWindow.java
@@ -40,8 +40,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
-import javax.vecmath.Color3f;
-import javax.vecmath.Point3f;
 
 import mmcorej.CMMCore;
 import mmcorej.TaggedImage;
@@ -65,6 +63,8 @@ import org.micromanager.imagedisplay.VirtualAcquisitionDisplay;
 import org.micromanager.utils.MDUtils;
 import org.micromanager.utils.MMScriptException;
 import org.micromanager.utils.ReportingUtils;
+import org.scijava.vecmath.Color3f;
+import org.scijava.vecmath.Point3f;
 
 import spim.algorithm.FitDisk;
 import spim.algorithm.FitHypersphere;


### PR DESCRIPTION
This means we no longer need users to install a Java 3D into their Java runtimes—we can just ship Java 3D with Fiji, avoiding Java-3D-related deployment issues.

Ultimately, we will switch again to the official Java 3D 1.7 (maintained by JogAmp; package prefixes `org.jogamp.java3d` and `org.jogamp.vecmath`). But it is not released yet, so for now we use the SciJava version; see:
- [scijava/java3d-core](https://github.com/scijava/java3d-core)
- [scijava/java3d-utils](https://github.com/scijava/java3d-utils)
- [scijava/vecmath](https://github.com/scijava/vecmath)

Note that this version of Java 3D requires Java 7; hence, SPIMAcquisition now requires Java 7 by extension.

For further details and rationale, see:
- [This (now outdated) forum post](http://forum.imagej.net/t/java-3d-progress-and-next-steps/135)
- [This JogAmp forum thread](forum.jogamp.org/Java-3D-Use-Maven-to-build-and-publish-Maven-artifacts-td4035555.html)
